### PR TITLE
fix: implement multi-touch steering while firing (Issue #50)

### DIFF
--- a/src/input.test.ts
+++ b/src/input.test.ts
@@ -145,8 +145,10 @@ describe('InputManager', () => {
 
   it('responds to touch movement', () => {
     // Touch start at (500, 500)
+    const touch0 = { identifier: 0, clientX: 500, clientY: 500, target: document.body };
     const touchStartEvent = {
-        touches: [{ clientX: 500, clientY: 500 }],
+        touches: [touch0],
+        changedTouches: [touch0],
         target: document.body,
         preventDefault: vi.fn()
     };
@@ -156,8 +158,10 @@ describe('InputManager', () => {
     expect(inputManager.getInput().y).toBe(0);
 
     // Touch move to (600, 400)
+    const touch0Moved = { identifier: 0, clientX: 600, clientY: 400, target: document.body };
     const touchMoveEvent = {
-        touches: [{ clientX: 600, clientY: 400 }],
+        touches: [touch0Moved],
+        changedTouches: [touch0Moved],
         preventDefault: vi.fn()
     };
     listeners['touchmove'](touchMoveEvent);
@@ -167,7 +171,11 @@ describe('InputManager', () => {
     expect(touchMoveEvent.preventDefault).toHaveBeenCalled();
 
     // Touch end
-    listeners['touchend']({ touches: [], target: document.body });
+    listeners['touchend']({
+        touches: [],
+        changedTouches: [touch0Moved],
+        target: document.body
+    });
     inputManager.update(0.1);
     // Vector magnitude decay:
     // Initial: (1, 1), Length: sqrt(2)
@@ -186,15 +194,19 @@ describe('InputManager', () => {
     vi.stubGlobal('innerWidth', 1000);
     vi.stubGlobal('innerHeight', 1000);
 
+    const touch0 = { identifier: 0, clientX: 500, clientY: 500, target: document.body };
     const touchStartEvent = {
-        touches: [{ clientX: 500, clientY: 500 }],
+        touches: [touch0],
+        changedTouches: [touch0],
         target: document.body,
         preventDefault: vi.fn()
     };
     listeners['touchstart'](touchStartEvent);
     
+    const touch0Moved = { identifier: 0, clientX: 600, clientY: 400, target: document.body };
     const touchMoveEvent = {
-        touches: [{ clientX: 600, clientY: 400 }],
+        touches: [touch0Moved],
+        changedTouches: [touch0Moved],
         preventDefault: vi.fn()
     };
     listeners['touchmove'](touchMoveEvent);
@@ -202,7 +214,12 @@ describe('InputManager', () => {
     expect(inputManager.getInput().x).toBe(1);
 
     // Touch cancel
-    listeners['touchcancel'](new TouchEvent('touchcancel'));
+    const cancelEvent = {
+        touches: [],
+        changedTouches: [touch0Moved],
+        target: document.body
+    };
+    listeners['touchcancel'](cancelEvent);
     
     // Should decay now
     inputManager.update(0.1);
@@ -281,8 +298,10 @@ describe('InputManager', () => {
 
   it('reports isFiring only when touch is on fire button', () => {
     // Touch on body should NOT fire
+    const touch0 = { identifier: 0, clientX: 500, clientY: 500, target: document.body };
     const bodyTouch = {
-        touches: [{ clientX: 500, clientY: 500 }],
+        touches: [touch0],
+        changedTouches: [touch0],
         target: document.body,
         preventDefault: vi.fn()
     };
@@ -290,8 +309,10 @@ describe('InputManager', () => {
     expect(inputManager.getInput().isFiring).toBe(false);
 
     // Touch on fire button SHOULD fire
+    const touch1 = { identifier: 1, clientX: 900, clientY: 900, target: fireButton };
     const buttonTouch = {
-        touches: [{ clientX: 900, clientY: 900 }],
+        touches: [touch0, touch1],
+        changedTouches: [touch1],
         target: fireButton,
         preventDefault: vi.fn()
     };
@@ -299,7 +320,11 @@ describe('InputManager', () => {
     expect(inputManager.getInput().isFiring).toBe(true);
     expect(buttonTouch.preventDefault).toHaveBeenCalled();
 
-    listeners['touchend']({ touches: [], target: fireButton });
+    listeners['touchend']({
+        touches: [touch0],
+        changedTouches: [touch1],
+        target: fireButton
+    });
     expect(inputManager.getInput().isFiring).toBe(false);
   });
 

--- a/src/repro_issue_50.test.ts
+++ b/src/repro_issue_50.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { InputManager } from './input';
+import { state } from './state';
+
+describe('InputManager Multi-touch Repro (Issue #50)', () => {
+  let inputManager: InputManager;
+  let listeners: Record<string, any> = {};
+  let fireButton: HTMLButtonElement;
+
+  beforeEach(() => {
+    listeners = {};
+    vi.stubGlobal('innerWidth', 1000);
+    vi.stubGlobal('innerHeight', 1000);
+    state.viewport.width = 1000;
+    state.viewport.height = 1000;
+    state.viewport.centerX = 500;
+    state.viewport.centerY = 500;
+
+    // Create fire button
+    fireButton = document.createElement('button');
+    fireButton.id = 'fire-button';
+    document.body.appendChild(fireButton);
+    
+    vi.spyOn(window, 'addEventListener').mockImplementation((event, listener) => {
+        listeners[event] = listener;
+    });
+    inputManager = new InputManager();
+    inputManager.setup();
+  });
+
+  afterEach(() => {
+      vi.restoreAllMocks();
+      inputManager.teardown();
+      if (document.body.contains(fireButton)) {
+        document.body.removeChild(fireButton);
+      }
+  });
+
+  it('calculates steering relative to the second touch when the first touch is on the fire button', () => {
+    // 1. Touch Fire Button (Touch 0)
+    const touch0 = { identifier: 0, clientX: 900, clientY: 900, target: fireButton };
+    listeners['touchstart']({
+        touches: [touch0],
+        changedTouches: [touch0],
+        target: fireButton,
+        preventDefault: vi.fn()
+    });
+    
+    expect(inputManager.getInput().isFiring).toBe(true);
+    expect(inputManager.getInput().x).toBe(0);
+    expect(inputManager.getInput().y).toBe(0);
+
+    // 2. Touch Screen for steering (Touch 1)
+    const touch1 = { identifier: 1, clientX: 500, clientY: 500, target: document.body };
+    listeners['touchstart']({
+        touches: [touch0, touch1],
+        changedTouches: [touch1],
+        target: document.body,
+        preventDefault: vi.fn()
+    });
+
+    // Currently, InputManager might incorrectly use touch0 as anchor if it doesn't track identifiers
+    // Or it might just not start dragging because it already thinks it's firing?
+    // Let's see what happens.
+
+    // 3. Move Touch 1
+    const touch1Moved = { identifier: 1, clientX: 550, clientY: 450, target: document.body };
+    listeners['touchmove']({
+        touches: [touch0, touch1Moved],
+        changedTouches: [touch1Moved],
+        preventDefault: vi.fn()
+    });
+
+    inputManager.update(0);
+    
+    // Expected: relative to (500, 500), moved +50 in X, +50 in Y (inverted clientY)
+    // dx = 550 - 500 = 50
+    // dy = 500 - 450 = 50
+    // touchRadius = 100
+    // x = 50/100 = 0.5
+    // y = 50/100 = 0.5
+    
+    const input = inputManager.getInput();
+    expect(input.isFiring).toBe(true);
+    
+    // This is expected to FAIL with current implementation
+    // Current implementation uses touches[0] (the fire button) as anchor if it started drag
+    // OR it might use touches[0] in touchmove.
+    expect(input.x).toBeCloseTo(0.5);
+    expect(input.y).toBeCloseTo(0.5);
+  });
+
+  it('lifting fire button does not stop steering', () => {
+    // 1. Touch Steering (Touch 0)
+    const touch0 = { identifier: 0, clientX: 500, clientY: 500, target: document.body };
+    listeners['touchstart']({
+        touches: [touch0],
+        changedTouches: [touch0],
+        target: document.body,
+        preventDefault: vi.fn()
+    });
+
+    // 2. Touch Fire (Touch 1)
+    const touch1 = { identifier: 1, clientX: 900, clientY: 900, target: fireButton };
+    listeners['touchstart']({
+        touches: [touch0, touch1],
+        changedTouches: [touch1],
+        target: fireButton,
+        preventDefault: vi.fn()
+    });
+
+    // 3. Move Steering (Touch 0)
+    const touch0Moved = { identifier: 0, clientX: 550, clientY: 450, target: document.body };
+    listeners['touchmove']({
+        touches: [touch0Moved, touch1],
+        changedTouches: [touch0Moved],
+        preventDefault: vi.fn()
+    });
+
+    inputManager.update(0);
+    expect(inputManager.getInput().x).toBeCloseTo(0.5);
+    expect(inputManager.getInput().isFiring).toBe(true);
+
+    // 4. Lift Fire (Touch 1)
+    listeners['touchend']({
+        touches: [touch0Moved],
+        changedTouches: [touch1],
+        target: fireButton,
+        preventDefault: vi.fn()
+    });
+
+    inputManager.update(0);
+    // Should still be steering
+    expect(inputManager.getInput().x).toBeCloseTo(0.5);
+    expect(inputManager.getInput().isFiring).toBe(false);
+  });
+});


### PR DESCRIPTION
- Add dragTouchId to InputManager to track the specific finger used for steering.
- Update touch event handlers to use touch identifiers.
- Ensure steering is independent of the fire button status.
- Add regression tests for multi-touch scenarios.

Closes https://github.com/gfxblit/vibe-wars/issues/50