### PR TITLE
Refactor tests to use GameConfig.player.baseForwardSpeed

### DIFF
--- a/src/entities/DumbAIStrategy.test.ts
+++ b/src/entities/DumbAIStrategy.test.ts
@@ -19,7 +19,7 @@ describe('DumbAIStrategy', () => {
   })
 
   test('update should move entity ahead of player', () => {
-    strategy.update(0.1, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+    strategy.update(0.1, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
 
     const expectedZ = -GameConfig.tieFighter.distance;
     expect(entityPosition.z).toBeCloseTo(expectedZ, 1);
@@ -27,7 +27,7 @@ describe('DumbAIStrategy', () => {
 
   test('update should include horizontal oscillation', () => {
     const deltaTime = 0.5;
-    strategy.update(deltaTime, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+    strategy.update(deltaTime, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
 
     const freq = GameConfig.tieFighter.oscillationFrequency;
     const amp = GameConfig.tieFighter.oscillationAmplitude;
@@ -38,7 +38,7 @@ describe('DumbAIStrategy', () => {
 
   test('update should align entity rotation with player', () => {
     playerQuaternion.setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI / 4);
-    strategy.update(0.1, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+    strategy.update(0.1, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
 
     expect(entityQuaternion.x).toBeCloseTo(playerQuaternion.x);
     expect(entityQuaternion.y).toBeCloseTo(playerQuaternion.y);

--- a/src/entities/EntityManager.test.ts
+++ b/src/entities/EntityManager.test.ts
@@ -42,7 +42,7 @@ describe('EntityManager', () => {
     // We need to make sure the strategy doesn't move it back during update
     vi.spyOn(actualTf, 'update').mockReturnValue(new THREE.Vector3());
 
-    entityManager.update(0.1, playerPosition, playerQuaternion, true, new THREE.PerspectiveCamera(), 100);
+    entityManager.update(0.1, playerPosition, playerQuaternion, true, new THREE.PerspectiveCamera(), GameConfig.player.baseForwardSpeed);
 
     expect(entityManager.getTieFighters().length).toBe(0);
     expect(scene.children.length).toBe(0);
@@ -88,14 +88,14 @@ describe('EntityManager', () => {
     // prevDist = dot(90-100, -1) = 10
     // currDist = dot(95-100, -1) = 5
     // Threshold=1.5. No hit.
-    entityManager.update(0.05, playerPosition, playerQuaternion, false, camera, 100, onHit);
+    entityManager.update(0.05, playerPosition, playerQuaternion, false, camera, GameConfig.player.baseForwardSpeed, onHit);
     expect(onHit).not.toHaveBeenCalled();
     expect(fb.isExploded).toBe(false);
 
     // Update 2: moves from 95 to 95 + (100 * 0.05) = 100
     // Player is at 100. fb is at 100.
     // currDist = dot(100-100, -1) = 0. HIT!
-    entityManager.update(0.05, playerPosition, playerQuaternion, false, camera, 100, onHit);
+    entityManager.update(0.05, playerPosition, playerQuaternion, false, camera, GameConfig.player.baseForwardSpeed, onHit);
     expect(onHit).toHaveBeenCalled();
     expect(fb.isExploded).toBe(true);
   })

--- a/src/entities/EntityManager_Collision.test.ts
+++ b/src/entities/EntityManager_Collision.test.ts
@@ -33,7 +33,7 @@ describe('EntityManager Collision', () => {
     const fireball = entityManager.spawnFireball(fbPos, fbVel);
 
     // Moves to z = +2.0 (behind camera). Crossing 1.5, 0, etc.
-    entityManager.update(0.1, playerPosition, playerQuaternion, false, mockCamera, 100, onPlayerHit);
+    entityManager.update(0.1, playerPosition, playerQuaternion, false, mockCamera, GameConfig.player.baseForwardSpeed, onPlayerHit);
 
     expect(onPlayerHit).toHaveBeenCalledWith(GameConfig.fireball.damage);
     expect(fireball.isExploded).toBe(true);
@@ -46,7 +46,7 @@ describe('EntityManager Collision', () => {
     const fbVel = new THREE.Vector3(0, 0, 40);
     const fireball = entityManager.spawnFireball(fbPos, fbVel);
 
-    entityManager.update(0.1, playerPosition, playerQuaternion, false, mockCamera, 100, onPlayerHit);
+    entityManager.update(0.1, playerPosition, playerQuaternion, false, mockCamera, GameConfig.player.baseForwardSpeed, onPlayerHit);
 
     expect(onPlayerHit).not.toHaveBeenCalled();
     expect(fireball.isExploded).toBe(false);
@@ -59,7 +59,7 @@ describe('EntityManager Collision', () => {
     const fbVel = new THREE.Vector3(0, 0, 20); // Moves to -8.0
     const fireball = entityManager.spawnFireball(fbPos, fbVel);
 
-    entityManager.update(0.1, playerPosition, playerQuaternion, false, mockCamera, 100, onPlayerHit);
+    entityManager.update(0.1, playerPosition, playerQuaternion, false, mockCamera, GameConfig.player.baseForwardSpeed, onPlayerHit);
 
     expect(onPlayerHit).not.toHaveBeenCalled();
     expect(fireball.isExploded).toBe(false);
@@ -72,7 +72,7 @@ describe('EntityManager Collision', () => {
     const fbVel = new THREE.Vector3(0, 0, 40);
     const fireball = entityManager.spawnFireball(fbPos, fbVel);
 
-    entityManager.update(0.1, playerPosition, playerQuaternion, false, mockCamera, 100, onPlayerHit);
+    entityManager.update(0.1, playerPosition, playerQuaternion, false, mockCamera, GameConfig.player.baseForwardSpeed, onPlayerHit);
 
     expect(onPlayerHit).not.toHaveBeenCalled();
     expect(fireball.isExploded).toBe(false);

--- a/src/entities/Player.test.ts
+++ b/src/entities/Player.test.ts
@@ -68,26 +68,26 @@ describe('Player', () => {
   })
 
   it('update should bank the visual mesh based on input x', () => {
-    player.update({ x: 1, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.1, 100);
+    player.update({ x: 1, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.1, GameConfig.player.baseForwardSpeed);
     // @ts-ignore - access private visualMesh via property if needed or check rotation.z
     expect(player.mesh.children[0].rotation.z).toBeLessThan(0);
   })
 
   it('update should rotate the player mesh based on input y', () => {
     const initialQuat = player.mesh.quaternion.clone();
-    player.update({ x: 0, y: 1, isFiring: false, isLaunchingTorpedo: false }, 0.1, 100);
+    player.update({ x: 0, y: 1, isFiring: false, isLaunchingTorpedo: false }, 0.1, GameConfig.player.baseForwardSpeed);
     expect(player.mesh.quaternion.equals(initialQuat)).toBe(false);
   })
 
   it('should rotate over time with horizontal input', () => {
     const startQuat = player.mesh.quaternion.clone();
-    player.update({ x: 1, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.5, 100);
+    player.update({ x: 1, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.5, GameConfig.player.baseForwardSpeed);
     expect(player.mesh.quaternion.equals(startQuat)).toBe(false);
   })
 
   it('should rotate over time with vertical input', () => {
     const startQuat = player.mesh.quaternion.clone();
-    player.update({ x: 0, y: 1, isFiring: false, isLaunchingTorpedo: false }, 0.5, 100);
+    player.update({ x: 0, y: 1, isFiring: false, isLaunchingTorpedo: false }, 0.5, GameConfig.player.baseForwardSpeed);
     expect(player.mesh.quaternion.equals(startQuat)).toBe(false);
   })
 
@@ -115,11 +115,11 @@ describe('Player', () => {
     expect(visualMesh.visible).toBe(false);
 
     // Toggle on
-    player.update({ x: 0, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.1, 100, true);
+    player.update({ x: 0, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.1, GameConfig.player.baseForwardSpeed, true);
     expect(visualMesh.visible).toBe(true);
 
     // Toggle off
-    player.update({ x: 0, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.1, 100, false);
+    player.update({ x: 0, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.1, GameConfig.player.baseForwardSpeed, false);
     expect(visualMesh.visible).toBe(false);
   })
 })

--- a/src/entities/QuatTurning.test.ts
+++ b/src/entities/QuatTurning.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, describe } from 'vitest'
 import { Player } from './Player'
 import * as THREE from 'three'
+import { GameConfig } from '../config'
 
 describe('Player Quaternion Turning', () => {
   test('turning on a level plane should not change forward.y', () => {
@@ -8,7 +9,7 @@ describe('Player Quaternion Turning', () => {
     
     // Initial state: looking at -Z, level.
     // Give X input (turn right).
-    player.update({ x: 1, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.1, 100);
+    player.update({ x: 1, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.1, GameConfig.player.baseForwardSpeed);
     
     const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(player.mesh.quaternion);
     
@@ -23,7 +24,7 @@ describe('Player Quaternion Turning', () => {
     // 1. Pitch up 45 degrees
     // TURN_SPEED_PITCH is Math.PI / 1.5
     // 45 deg = (PI/4) / (PI/1.5) = 1.5/4 = 0.375s
-    player.update({ x: 0, y: 1, isFiring: false, isLaunchingTorpedo: false }, 0.375, 100);
+    player.update({ x: 0, y: 1, isFiring: false, isLaunchingTorpedo: false }, 0.375, GameConfig.player.baseForwardSpeed);
     
     let forward = new THREE.Vector3(0, 0, -1).applyQuaternion(player.mesh.quaternion);
     expect(forward.y).toBeCloseTo(Math.sin(Math.PI / 4), 5);
@@ -31,7 +32,7 @@ describe('Player Quaternion Turning', () => {
     // 2. Yaw right 90 degrees
     // TURN_SPEED_YAW is Math.PI / 1.5
     // 90 deg = (PI/2) / (PI/1.5) = 1.5/2 = 0.75s
-    player.update({ x: 1, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.75, 100);
+    player.update({ x: 1, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.75, GameConfig.player.baseForwardSpeed);
     
     forward = new THREE.Vector3(0, 0, -1).applyQuaternion(player.mesh.quaternion);
     

--- a/src/entities/RelativeTurning.test.ts
+++ b/src/entities/RelativeTurning.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, describe } from 'vitest'
 import { Player } from './Player'
 import * as THREE from 'three'
+import { GameConfig } from '../config'
 
 describe('Player Relative Turning', () => {
   test('yaw should be relative to current orientation, not world Y', () => {
@@ -9,7 +10,7 @@ describe('Player Relative Turning', () => {
     // 1. Pitch up 90 degrees (looking straight up at +Y)
     // TURN_SPEED_PITCH is Math.PI / 1.5
     // 90 deg is 0.75s
-    player.update({ x: 0, y: 1, isFiring: false, isLaunchingTorpedo: false }, 0.75, 100);
+    player.update({ x: 0, y: 1, isFiring: false, isLaunchingTorpedo: false }, 0.75, GameConfig.player.baseForwardSpeed);
     
     // Confirm we are looking UP
     const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(player.mesh.quaternion);
@@ -30,7 +31,7 @@ describe('Player Relative Turning', () => {
     // WAIT. If Local Up is World -Z, and Local Forward is World +Y.
     // Rotating around Local Up (-Z) will rotate the Forward vector (+Y) in the XY plane.
     
-    player.update({ x: 1, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.1, 100);
+    player.update({ x: 1, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.1, GameConfig.player.baseForwardSpeed);
     
     const newForward = new THREE.Vector3(0, 0, -1).applyQuaternion(player.mesh.quaternion);
     

--- a/src/entities/RelativeTurningBank.test.ts
+++ b/src/entities/RelativeTurningBank.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, describe } from 'vitest'
 import { Player } from './Player'
 import * as THREE from 'three'
+import { GameConfig } from '../config'
 
 describe('Player Relative Turning with Bank', () => {
   test('turning while banked should be relative to the banked orientation', () => {
@@ -14,7 +15,7 @@ describe('Player Relative Turning with Bank', () => {
     // Initial state: Forward = -Z, Up = +Y, Right = +X.
     // Bank right 45 deg: New Up = (+0.707, +0.707, 0) approx, New Right = (+0.707, -0.707, 0) approx.
     
-    player.update({ x: 1, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.1, 100);
+    player.update({ x: 1, y: 0, isFiring: false, isLaunchingTorpedo: false }, 0.1, GameConfig.player.baseForwardSpeed);
     
     const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(player.mesh.quaternion);
     

--- a/src/entities/SmartAIStrategy.test.ts
+++ b/src/entities/SmartAIStrategy.test.ts
@@ -25,12 +25,12 @@ describe('SmartAIStrategy', () => {
 
   test('should initialize behind player and move forward', () => {
     // First update initializes
-    strategy.update(0, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+    strategy.update(0, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
     // with 0.5, random offset is 0.
     expect(entityPosition.z).toBeCloseTo(GameConfig.tieFighter.spawnDistanceBehind + 0.5 * GameConfig.tieFighter.smartSpawnRandomZ, 1);
 
     const initialZ = entityPosition.z;
-    strategy.update(0.1, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+    strategy.update(0.1, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
     expect(entityPosition.z).toBeLessThan(initialZ);
   })
 
@@ -46,7 +46,7 @@ describe('SmartAIStrategy', () => {
 
     const rngStrategy = new SmartAIStrategy(mockRng);
     // elapsedTime will be 0 on first update
-    rngStrategy.update(0, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+    rngStrategy.update(0, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
 
     // offset.x = (0.6 - 0.5) * smartSpawnRandomX = 0.1 * 40 = 4
     // xOsc = sin(0) = 0
@@ -56,10 +56,10 @@ describe('SmartAIStrategy', () => {
   })
 
   test('should face direction of motion', () => {
-    strategy.update(0, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+    strategy.update(0, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
     const pos1 = entityPosition.clone();
 
-    strategy.update(0.1, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+    strategy.update(0.1, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
     const pos2 = entityPosition.clone();
 
     const velocity = pos2.clone().sub(pos1).normalize();
@@ -77,12 +77,12 @@ describe('SmartAIStrategy', () => {
     // Initial Z is around 100. relativeSpeed is smartSpeed (180) - playerSpeed (100) = 80.
     // Takes about 1.25s to reach Z=0.
 
-    strategy.update(0, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+    strategy.update(0, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
 
     // Check lateral movement near Z=0 and during shadow stage
     let maxLateralMovement = 0;
     for (let t = 0; t < 5; t += 0.1) {
-      strategy.update(0.1, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+      strategy.update(0.1, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
       const lateralDist = Math.sqrt(entityPosition.x * entityPosition.x + entityPosition.y * entityPosition.y);
       maxLateralMovement = Math.max(maxLateralMovement, lateralDist);
     }
@@ -92,32 +92,32 @@ describe('SmartAIStrategy', () => {
   })
 
   test('should maintain constant distance during shadowing stage', () => {
-    strategy.update(0, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+    strategy.update(0, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
 
     // Fast forward to shadowing stage
     // relative speed is 80, distance to -50 is 150-200. 
     // Braking zone is 60. 
     // We need enough time to decelerate smoothly to the 0.1 threshold.
     for (let t = 0; t < 8.0; t += 0.1) {
-      strategy.update(0.1, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+      strategy.update(0.1, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
     }
 
     // Now it should be shadowing at -50
     expect(entityPosition.z).toBeCloseTo(GameConfig.tieFighter.smartShadowDistance, 0);
 
     const zBefore = entityPosition.z;
-    strategy.update(0.5, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+    strategy.update(0.5, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
     // Should still be at -50
     expect(entityPosition.z).toBeCloseTo(zBefore, 0.1);
 
     // Wait for shadow duration (3s)
     for (let t = 0; t < 3.0; t += 0.5) {
-      strategy.update(0.5, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+      strategy.update(0.5, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
     }
 
     // Now it should be escaping
     const zShadow = entityPosition.z;
-    strategy.update(0.5, entityPosition, entityQuaternion, playerPosition, playerQuaternion, 100);
+    strategy.update(0.5, entityPosition, entityQuaternion, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
     expect(entityPosition.z).toBeLessThan(zShadow);
   })
 })

--- a/src/entities/TieFighter.test.ts
+++ b/src/entities/TieFighter.test.ts
@@ -22,7 +22,7 @@ describe('TieFighter', () => {
   })
 
   test('update should move TieFighter ahead of the player', () => {
-    tieFighter.update(0, playerPosition, playerQuaternion, 100);
+    tieFighter.update(0, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
 
     const expectedZ = -GameConfig.tieFighter.distance;
     expect(tieFighter.position.z).toBeCloseTo(expectedZ, 1);
@@ -31,7 +31,7 @@ describe('TieFighter', () => {
 
   test('update should follow player position', () => {
     playerPosition.set(10, 20, 30);
-    tieFighter.update(0, playerPosition, playerQuaternion, 100);
+    tieFighter.update(0, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
 
     const expectedZ = 30 - GameConfig.tieFighter.distance;
     expect(tieFighter.position.z).toBeCloseTo(expectedZ, 1);
@@ -42,7 +42,7 @@ describe('TieFighter', () => {
   test('update should follow player rotation', () => {
     playerQuaternion.setFromAxisAngle(new THREE.Vector3(0, 1, 0), -Math.PI / 2);
 
-    tieFighter.update(0, playerPosition, playerQuaternion, 100);
+    tieFighter.update(0, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
 
     const expectedX = GameConfig.tieFighter.distance;
     expect(tieFighter.position.x).toBeCloseTo(expectedX, 1);
@@ -54,7 +54,7 @@ describe('TieFighter', () => {
     const amp = GameConfig.tieFighter.oscillationAmplitude;
 
     // at t = 0.5, oscillation should be sin(0.5 * freq) * amp
-    tieFighter.update(0.5, playerPosition, playerQuaternion, 100);
+    tieFighter.update(0.5, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
     const expectedX = Math.sin(0.5 * freq) * amp;
     expect(tieFighter.position.x).toBeCloseTo(expectedX, 1);
   })
@@ -86,7 +86,7 @@ describe('TieFighter', () => {
     tieFighter.explode();
 
     // Update a few times
-    tieFighter.update(0.1, playerPosition, playerQuaternion, 100);
+    tieFighter.update(0.1, playerPosition, playerQuaternion, GameConfig.player.baseForwardSpeed);
 
     // Pieces should have moved relative to the group
     expect(piece1.position.equals(initialPos)).toBe(false);
@@ -128,14 +128,14 @@ describe('TieFighter', () => {
 
     const smartTieFighter = new TieFighter(new SmartAIStrategy());
 
-    smartTieFighter.update(0.01, playerPos, playerQuat, 100);
+    smartTieFighter.update(0.01, playerPos, playerQuat, GameConfig.player.baseForwardSpeed);
     // It should be behind the player (Z > 0)
     expect(smartTieFighter.position.z).toBeGreaterThan(0);
 
     const initialZ = smartTieFighter.position.z;
 
     // Update after 1 second, it should have moved forward (towards negative Z)
-    smartTieFighter.update(1, playerPos, playerQuat, 100);
+    smartTieFighter.update(1, playerPos, playerQuat, GameConfig.player.baseForwardSpeed);
     expect(smartTieFighter.position.z).toBeLessThan(initialZ);
   })
 

--- a/src/entities/repro_tunneling.test.ts
+++ b/src/entities/repro_tunneling.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, describe, beforeEach, vi } from 'vitest'
 import * as THREE from 'three'
 import { EntityManager } from './EntityManager'
+import { GameConfig } from '../config'
 
 describe('EntityManager Tunneling Repro', () => {
   let scene: THREE.Scene;
@@ -36,7 +37,7 @@ describe('EntityManager Tunneling Repro', () => {
 
     // This update will move fireball from -2.0 to 3.0.
     // Crossing the threshold at 1.5.
-    entityManager.update(0.05, playerPosition, playerQuaternion, false, mockCamera, 100, onPlayerHit);
+    entityManager.update(0.05, playerPosition, playerQuaternion, false, mockCamera, GameConfig.player.baseForwardSpeed, onPlayerHit);
 
     expect(onPlayerHit).toHaveBeenCalled();
     expect(fireball.isExploded).toBe(true);


### PR DESCRIPTION
Replaced hardcoded `100` with `GameConfig.player.baseForwardSpeed` in multiple test files to address PR comments and improve maintainability. Added `import { GameConfig }` where missing. verified with `npm test`.

---
*PR created automatically by Jules for task [10957025692047378865](https://jules.google.com/task/10957025692047378865) started by @gfxblit*