### PR TITLE
don t show star field in the trench stage issue111

### DIFF
--- a/src/entities/StarField.test.ts
+++ b/src/entities/StarField.test.ts
@@ -76,19 +76,13 @@ describe('StarField', () => {
     expect(starField.points.frustumCulled).toBe(false);
   })
 
-  test('should update visibility based on stage', () => {
+  test('should allow manual visibility control', () => {
     const starField = new StarField();
     
-    starField.updateVisibility('DOGFIGHT');
+    starField.points.visible = true;
     expect(starField.points.visible).toBe(true);
 
-    starField.updateVisibility('SURFACE');
+    starField.points.visible = false;
     expect(starField.points.visible).toBe(false);
-
-    starField.updateVisibility('TRENCH');
-    expect(starField.points.visible).toBe(false);
-
-    starField.updateVisibility('EXPLOSION');
-    expect(starField.points.visible).toBe(true);
   })
 })

--- a/src/entities/StarField.ts
+++ b/src/entities/StarField.ts
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import { Entity } from './Entity';
 import { GameConfig } from '../config';
-import { GameStage } from '../state';
 
 export class StarField extends Entity {
   public readonly points: THREE.Points;
@@ -60,9 +59,5 @@ export class StarField extends Entity {
       }
     }
     this.geometry.attributes.position.needsUpdate = true;
-  }
-
-  public updateVisibility(stage: GameStage) {
-    this.points.visible = stage === 'DOGFIGHT' || stage === 'EXPLOSION';
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ function animate(time: number) {
 
   // Render
   if (state.player) {
-    starField.updateVisibility(state.stage)
+    starField.points.visible = state.stageManager?.getStage()?.showStarField ?? false;
     if (starField.points.visible) {
       starField.update(state.player.position)
     }

--- a/src/stages/DogfightStage.ts
+++ b/src/stages/DogfightStage.ts
@@ -30,6 +30,10 @@ export class DogfightStage extends Stage {
       : GameConfig.player.forwardSpeeds.DOGFIGHT;
   }
 
+  public override get showStarField(): boolean {
+    return true;
+  }
+
   public update(deltaTime: number, player: Player, _camera: THREE.Camera): void {
     if (this.phase === DogfightPhase.COMBAT) {
       const threshold = state.debugKillsThreshold ?? GameConfig.stage.dogfightKillsThreshold;

--- a/src/stages/ExplosionStage.ts
+++ b/src/stages/ExplosionStage.ts
@@ -7,6 +7,7 @@ import { DeathStar } from '../entities/DeathStar';
 
 export class ExplosionStage extends Stage {
   public override get speed() { return GameConfig.explosionStage.escapeSpeed; }
+  public override get showStarField(): boolean { return true; }
   private deathStar: DeathStar;
   private elapsedTime: number = 0;
   private hasExploded: boolean = false;

--- a/src/stages/Stage.ts
+++ b/src/stages/Stage.ts
@@ -6,6 +6,9 @@ export abstract class Stage {
   public abstract get speed(): number;
   public abstract update(deltaTime: number, player: Player, camera: THREE.Camera): void;
   public abstract cleanup(): void;
+  public get showStarField(): boolean {
+    return false;
+  }
   public getTurrets(): Turret[] {
     return [];
   }


### PR DESCRIPTION
- **Hide star field in TRENCH and SURFACE stages, show in EXPLOSION**
- **refactor: decouple StarField visibility from stage types**

Closes https://github.com/gfxblit/vibe-wars/issues/111