### PR TITLE
🎨 Palette: Add Restart Button & A11y Fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         </g>
       </svg>
     </div>
-    <button id="fire-button">FIRE</button>
+    <button id="fire-button" aria-label="Fire Weapon">FIRE</button>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/UIManager.ts
+++ b/src/UIManager.ts
@@ -290,10 +290,16 @@ export class UIManager {
   }
 
   private createGameOverOverlay() {
-    this.gameOver = this.createEl('div', 'fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 hidden z-50', this.hud);
+    this.gameOver = this.createEl('div', 'fixed inset-0 flex flex-col items-center justify-center bg-black bg-opacity-70 hidden z-50 pointer-events-auto', this.hud);
     this.gameOver.id = 'game-over';
-    const text = this.createEl('div', 'text-vector-red text-6xl font-retro animate-pulse', this.gameOver);
+
+    const text = this.createEl('div', 'text-vector-red text-6xl font-retro animate-pulse mb-8', this.gameOver);
     text.textContent = 'GAME OVER';
+
+    const restartBtn = this.createEl('button', 'px-8 py-3 border-2 border-vector-green text-vector-green hover:bg-vector-green hover:text-black font-retro text-2xl transition-colors focus:outline-none focus:ring-2 focus:ring-vector-green focus:ring-offset-2 focus:ring-offset-black', this.gameOver);
+    restartBtn.textContent = 'RESTART MISSION';
+    restartBtn.setAttribute('aria-label', 'Restart Game');
+    restartBtn.onclick = () => window.location.reload();
   }
 
   destroy() {


### PR DESCRIPTION
This PR introduces small but impactful UX improvements:
1.  **Restart Button:** Added a "RESTART MISSION" button to the Game Over screen. Previously, players had to manually refresh the browser to restart the game. This button reloads the page via `window.location.reload()`, providing a smoother loop.
2.  **Accessibility:** Added `aria-label="Fire Weapon"` to the mobile fire button (`#fire-button`) in `index.html` to improve accessibility for screen reader users.

The changes were verified visually using a Playwright script and manually inspecting the DOM structure and attributes. All existing tests passed.


---
*PR created automatically by Jules for task [3572772814100639004](https://jules.google.com/task/3572772814100639004) started by @gfxblit*