### PR TITLE
⚡ Bolt: Optimize Laser entity allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [Vector and Material Allocation in High-Frequency Entities]
+**Learning:** High-frequency entities like `Laser` were allocating new `THREE.PlaneGeometry` and `THREE.MeshBasicMaterial` for every instance, along with multiple `THREE.Vector2` allocations per frame for position updates. In THREE.js, geometries and materials should be shared across identical instances to reduce draw calls (if instanced) or at least reduce memory pressure and GC overhead.
+**Action:** For projectile entities, always implement static caching for Geometry and Material. Avoid `new THREE.Vector2()` in `update()` loops; use static scratch vectors or manual scalar math for simple linear interpolations.

--- a/src/entities/EntityManager.ts
+++ b/src/entities/EntityManager.ts
@@ -196,8 +196,8 @@ export class EntityManager {
     return fireball;
   }
 
-  public spawnLaser(origin2D: THREE.Vector2, target2D: THREE.Vector2, color: number): Laser {
-    const laser = new Laser(origin2D, target2D, color);
+  public spawnLaser(originX: number, originY: number, targetX: number, targetY: number, color: number): Laser {
+    const laser = new Laser(originX, originY, targetX, targetY, color);
     this.lasers.push(laser);
     this.hudScene.add(laser.mesh);
     return laser;

--- a/src/entities/Laser.test.ts
+++ b/src/entities/Laser.test.ts
@@ -4,9 +4,7 @@ import { Laser } from './Laser';
 
 describe('Laser (HUD-based)', () => {
   it('updates progress and moves the mesh', () => {
-    const origin = new THREE.Vector2(-1, 1);
-    const target = new THREE.Vector2(0, 0);
-    const laser = new Laser(origin, target, 0xffffff);
+    const laser = new Laser(-1, 1, 0, 0, 0xffffff);
     
     const initialPosition = laser.mesh.position.clone();
     laser.update(0.05);
@@ -14,9 +12,7 @@ describe('Laser (HUD-based)', () => {
   });
 
   it('expires when progress reaches 1.0', () => {
-    const origin = new THREE.Vector2(-1, 1);
-    const target = new THREE.Vector2(0, 0);
-    const laser = new Laser(origin, target, 0xffffff);
+    const laser = new Laser(-1, 1, 0, 0, 0xffffff);
     
     expect(laser.isExpired()).toBe(false);
     
@@ -25,14 +21,26 @@ describe('Laser (HUD-based)', () => {
     expect(laser.isExpired()).toBe(true);
   });
 
-  it('disposes of geometry and material', () => {
-    const laser = new Laser(new THREE.Vector2(), new THREE.Vector2(), 0xffffff);
+  it('reuses geometry and material', () => {
+    const laser1 = new Laser(0, 0, 1, 1, 0xff0000);
+    const laser2 = new Laser(0, 0, 1, 1, 0xff0000);
+    const laser3 = new Laser(0, 0, 1, 1, 0x00ff00);
+
+    expect(laser1.mesh.geometry).toBe(laser2.mesh.geometry);
+    expect(laser1.mesh.material).toBe(laser2.mesh.material);
+
+    expect(laser1.mesh.geometry).toBe(laser3.mesh.geometry);
+    expect(laser1.mesh.material).not.toBe(laser3.mesh.material);
+  });
+
+  it('dispose does NOT dispose shared geometry/material', () => {
+    const laser = new Laser(0, 0, 1, 1, 0xffffff);
     const geometryDisposeSpy = vi.spyOn(laser.mesh.geometry, 'dispose');
     const materialDisposeSpy = vi.spyOn(laser.mesh.material as THREE.Material, 'dispose');
     
     laser.dispose();
     
-    expect(geometryDisposeSpy).toHaveBeenCalled();
-    expect(materialDisposeSpy).toHaveBeenCalled();
+    expect(geometryDisposeSpy).not.toHaveBeenCalled();
+    expect(materialDisposeSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/entities/Laser.ts
+++ b/src/entities/Laser.ts
@@ -6,26 +6,41 @@ export class Laser extends Entity {
   public readonly mesh: THREE.Mesh;
   private progress: number = 0; // 0 to 1
   
-  private readonly origin2D: THREE.Vector2;
-  private readonly target2D: THREE.Vector2;
+  private readonly originX: number;
+  private readonly originY: number;
+  private readonly targetX: number;
+  private readonly targetY: number;
   private readonly color: number;
 
-  constructor(origin2D: THREE.Vector2, target2D: THREE.Vector2, color: number) {
+  private static geometry: THREE.PlaneGeometry;
+  private static materials: Map<number, THREE.MeshBasicMaterial> = new Map();
+
+  constructor(originX: number, originY: number, targetX: number, targetY: number, color: number) {
     super();
-    this.origin2D = origin2D.clone();
-    this.target2D = target2D.clone();
+    this.originX = originX;
+    this.originY = originY;
+    this.targetX = targetX;
+    this.targetY = targetY;
     this.color = color;
 
-    // A simple quad centered at origin, pointing up (+Y)
-    const geometry = new THREE.PlaneGeometry(1, 1);
-    const material = new THREE.MeshBasicMaterial({ 
-      color: this.color,
-      transparent: true,
-      opacity: 1.0,
-      depthTest: false
-    });
+    // Initialize static geometry if not exists
+    if (!Laser.geometry) {
+      Laser.geometry = new THREE.PlaneGeometry(1, 1);
+    }
+
+    // Get or create material
+    let material = Laser.materials.get(color);
+    if (!material) {
+      material = new THREE.MeshBasicMaterial({
+        color: this.color,
+        transparent: true,
+        opacity: 1.0,
+        depthTest: false
+      });
+      Laser.materials.set(color, material);
+    }
     
-    this.mesh = new THREE.Mesh(geometry, material);
+    this.mesh = new THREE.Mesh(Laser.geometry, material);
     
     this.updateMeshTransform();
   }
@@ -38,16 +53,24 @@ export class Laser extends Entity {
     const startP = this.progress;
     const endP = Math.min(1.0, this.progress + normBoltLength);
 
-    const start = new THREE.Vector2().lerpVectors(this.origin2D, this.target2D, startP);
-    const end = new THREE.Vector2().lerpVectors(this.origin2D, this.target2D, endP);
+    // Linear interpolation manually to avoid Vector2 allocation
+    const startX = this.originX + (this.targetX - this.originX) * startP;
+    const startY = this.originY + (this.targetY - this.originY) * startP;
 
-    const delta = new THREE.Vector2().subVectors(end, start);
-    const length = delta.length();
-    const angle = Math.atan2(delta.y, delta.x);
+    const endX = this.originX + (this.targetX - this.originX) * endP;
+    const endY = this.originY + (this.targetY - this.originY) * endP;
+
+    const deltaX = endX - startX;
+    const deltaY = endY - startY;
+
+    const length = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+    const angle = Math.atan2(deltaY, deltaX);
 
     // Position at the center of the bolt segment
-    const center = new THREE.Vector2().lerpVectors(start, end, 0.5);
-    this.mesh.position.set(center.x, center.y, 0);
+    const centerX = (startX + endX) * 0.5;
+    const centerY = (startY + endY) * 0.5;
+
+    this.mesh.position.set(centerX, centerY, 0);
     
     // Rotate to align with trajectory
     // Standard PlaneGeometry(1,1) faces +Z, with its 'up' along +Y.
@@ -78,11 +101,7 @@ export class Laser extends Entity {
   }
 
   public dispose(): void {
-    this.mesh.geometry.dispose();
-    if (Array.isArray(this.mesh.material)) {
-      this.mesh.material.forEach(m => m.dispose());
-    } else {
-      this.mesh.material.dispose();
-    }
+    // Do NOT dispose shared geometry and material to allow reuse.
+    // EntityManager removes mesh from scene.
   }
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -173,10 +173,7 @@ export function spawnLasers(input: Pick<UserInput, 'x' | 'y'>): Laser[] {
     state.gunColorToggles[index] = !useAltColor; // Flip for next shot from this gun
 
     const offset = GameConfig.laser.offsets[index];
-    const origin2D = new THREE.Vector2(offset.x, offset.y);
-    const target2D = new THREE.Vector2(input.x, input.y);
-
-    const laser = state.entityManager!.spawnLaser(origin2D, target2D, color);
+    const laser = state.entityManager!.spawnLaser(offset.x, offset.y, input.x, input.y, color);
     newLasers.push(laser);
   });
 


### PR DESCRIPTION
⚡ Bolt: Optimize Laser entity allocation and update loop

💡 What:
- Implemented static sharing of `THREE.PlaneGeometry` and `THREE.MeshBasicMaterial` across all `Laser` instances.
- Replaced `THREE.Vector2` allocations in `Laser` constructor and `updateMeshTransform` with raw scalar math.
- Updated `EntityManager.spawnLaser` and `state.spawnLasers` to pass `x, y` numbers instead of `Vector2` objects.

🎯 Why:
- `Laser` entities are spawned frequently (every ~150ms during firing).
- Previously, each laser allocated:
  - 1 `PlaneGeometry`
  - 1 `MeshBasicMaterial`
  - 2 `Vector2` (origin/target)
  - 4 `Vector2` per frame in `update` loop (start, end, delta, center)
- This caused significant Garbage Collection pressure and memory churn.

📊 Impact:
- Reduces object allocations per laser shot from ~8 objects + geometry/material to 1 object (`Laser` instance) + 1 mesh.
- Eliminates 4 vector allocations per frame per active laser.
- Improves frame rate stability during intense dogfights.

 Microscope Measurement:
- Run `pnpm test` to verify no regressions.
- Check `src/entities/Laser.test.ts` for verification of resource reuse.

---
*PR created automatically by Jules for task [1162606955656617608](https://jules.google.com/task/1162606955656617608) started by @gfxblit*