### PR TITLE
🎨 Palette: Enable mouse look and hide default cursor

### DIFF
--- a/src/UIManager.ts
+++ b/src/UIManager.ts
@@ -4,7 +4,7 @@ import { GameConfig } from './config';
 type TimerHandle = number;
 
 export class UIManager {
-  private static readonly BUTTON_CLASSES = 'px-2 py-1 border border-vector-green hover:bg-vector-green hover:text-black transition-colors font-retro';
+  private static readonly BUTTON_CLASSES = 'px-2 py-1 border border-vector-green hover:bg-vector-green hover:text-black transition-colors font-retro cursor-pointer';
 
   private hud: HTMLElement;
   private scoreValue!: HTMLElement;
@@ -79,14 +79,14 @@ export class UIManager {
   }
 
   private createDebugPanel() {
-    this.debugPanel = this.createEl('div', 'fixed bottom-4 left-4 pointer-events-auto bg-black bg-opacity-70 border border-vector-green p-4 flex flex-col space-y-2 text-vector-green font-retro font-bold text-xs z-20', document.body);
+    this.debugPanel = this.createEl('div', 'fixed bottom-4 left-4 pointer-events-auto bg-black bg-opacity-70 border border-vector-green p-4 flex flex-col space-y-2 text-vector-green font-retro font-bold text-xs z-20 cursor-auto', document.body);
     this.debugPanel.id = 'debug-panel';
 
     const header = this.createEl('div', 'flex justify-between items-center mb-2 border-b border-vector-green pb-1', this.debugPanel);
     const title = this.createEl('div', '', header);
     title.textContent = 'DEBUG CONSOLE';
 
-    const toggleBtn = this.createEl('button', 'ml-4 hover:text-white transition-colors font-retro', header);
+    const toggleBtn = this.createEl('button', 'ml-4 hover:text-white transition-colors font-retro cursor-pointer', header);
     toggleBtn.id = 'debug-minimize-toggle';
     toggleBtn.textContent = '[-]';
 
@@ -152,7 +152,7 @@ export class UIManager {
 
     // Kills Threshold
     this.createEl('div', 'mt-4 mb-2 border-b border-vector-green pb-1', content).textContent = 'KILLS TO ADVANCE';
-    const killsInput = this.createEl('input', 'w-full bg-black text-vector-green border border-vector-green px-2 py-1', content) as HTMLInputElement;
+    const killsInput = this.createEl('input', 'w-full bg-black text-vector-green border border-vector-green px-2 py-1 cursor-text', content) as HTMLInputElement;
     killsInput.id = 'debug-kills-input';
     killsInput.type = 'number';
     killsInput.min = '0';
@@ -171,7 +171,7 @@ export class UIManager {
 
     // Turret Size
     this.createEl('div', 'mt-4 mb-2 border-b border-vector-green pb-1', content).textContent = 'TURRET SIZE';
-    const turretSizeInput = this.createEl('input', 'w-full bg-black text-vector-green border border-vector-green px-2 py-1', content) as HTMLInputElement;
+    const turretSizeInput = this.createEl('input', 'w-full bg-black text-vector-green border border-vector-green px-2 py-1 cursor-text', content) as HTMLInputElement;
     turretSizeInput.id = 'debug-turret-size-input';
     turretSizeInput.type = 'number';
     turretSizeInput.min = '1';
@@ -191,7 +191,7 @@ export class UIManager {
 
     // Fireball Size
     this.createEl('div', 'mt-4 mb-2 border-b border-vector-green pb-1', content).textContent = 'FIREBALL SIZE';
-    const fireballSizeInput = this.createEl('input', 'w-full bg-black text-vector-green border border-vector-green px-2 py-1', content) as HTMLInputElement;
+    const fireballSizeInput = this.createEl('input', 'w-full bg-black text-vector-green border border-vector-green px-2 py-1 cursor-text', content) as HTMLInputElement;
     fireballSizeInput.id = 'debug-fireball-size-input';
     fireballSizeInput.type = 'number';
     fireballSizeInput.min = '1';
@@ -292,13 +292,13 @@ export class UIManager {
   }
 
   private createGameOverOverlay() {
-    this.gameOver = this.createEl('div', 'fixed inset-0 flex flex-col items-center justify-center bg-black bg-opacity-70 hidden z-50 pointer-events-auto', this.hud);
+    this.gameOver = this.createEl('div', 'fixed inset-0 flex flex-col items-center justify-center bg-black bg-opacity-70 hidden z-50 pointer-events-auto cursor-auto', this.hud);
     this.gameOver.id = 'game-over';
 
     const text = this.createEl('div', 'text-vector-red text-6xl font-retro animate-pulse mb-8', this.gameOver);
     text.textContent = 'GAME OVER';
 
-    const restartBtn = this.createEl('button', 'px-8 py-3 border-2 border-vector-green text-vector-green hover:bg-vector-green hover:text-black font-retro text-2xl transition-colors focus:outline-none focus:ring-2 focus:ring-vector-green focus:ring-offset-2 focus:ring-offset-black', this.gameOver);
+    const restartBtn = this.createEl('button', 'px-8 py-3 border-2 border-vector-green text-vector-green hover:bg-vector-green hover:text-black font-retro text-2xl transition-colors focus:outline-none focus:ring-2 focus:ring-vector-green focus:ring-offset-2 focus:ring-offset-black cursor-pointer', this.gameOver);
     restartBtn.textContent = 'RESTART MISSION';
     restartBtn.setAttribute('aria-label', 'Restart Game');
     restartBtn.onclick = () => window.location.reload();

--- a/src/input.test.ts
+++ b/src/input.test.ts
@@ -117,10 +117,7 @@ describe('InputManager', () => {
     expect(inputManager.getInput().x).toBeLessThan(0);
   });
 
-  it('responds to mouse movement when dragging', () => {
-    // Mouse down on document body (not UI)
-    listeners['mousedown'](createMouseEvent('mousedown'));
-    
+  it('responds to mouse movement', () => {
     listeners['mousemove'](new MouseEvent('mousemove', { clientX: 0, clientY: 0 }));
     inputManager.update(0);
     
@@ -134,23 +131,18 @@ describe('InputManager', () => {
     expect(inputManager.getInput().y).toBe(0);
   });
 
-  it('resets to zero when mouse is released', () => {
-    listeners['mousedown'](createMouseEvent('mousedown'));
+  it('maintains position when mouse is released', () => {
     listeners['mousemove'](new MouseEvent('mousemove', { clientX: 0, clientY: 0 }));
     inputManager.update(0);
     expect(inputManager.getInput().x).toBe(-1);
 
     listeners['mouseup'](new MouseEvent('mouseup'));
     inputManager.update(0.1);
-    // Vector magnitude decay:
-    // Initial: (-1, 1), Length: sqrt(2)
-    // Step: 0.2 (2.0 speed * 0.1s)
-    // New Length: sqrt(2) - 0.2
-    // New X: -1 * (sqrt(2) - 0.2) / sqrt(2) = -0.8585...
-    expect(inputManager.getInput().x).toBeCloseTo(-0.858578);
+    // Expect NO decay
+    expect(inputManager.getInput().x).toBe(-1);
 
-    inputManager.update(1.0); // Should definitely be zero now
-    expect(inputManager.getInput().x).toBe(0);
+    inputManager.update(1.0);
+    expect(inputManager.getInput().x).toBe(-1);
   });
 
   it('responds to touch movement', () => {
@@ -277,15 +269,22 @@ describe('InputManager', () => {
      expect(inputManager.getInput().x).toBe(-1);
   });
 
-  it('returns to center in a straight line during decay', () => {
-    listeners['mousedown'](createMouseEvent('mousedown'));
-    // Set an off-axis position: x=0.8, y=0.4 (Ratio 2:1)
-    listeners['mousemove'](new MouseEvent('mousemove', { clientX: 900, clientY: 300 }));
+  it('returns to center in a straight line during decay (Touch)', () => {
+    // Touch start
+    const touch0 = { identifier: 0, clientX: 500, clientY: 500, target: document.body };
+    listeners['touchstart']({ touches: [touch0], changedTouches: [touch0], target: document.body, preventDefault: vi.fn() });
+
+    // Touch move to (580, 460) -> x=0.8, y=0.4 (touchRadius=100)
+    const touchMove = { identifier: 0, clientX: 580, clientY: 460, target: document.body };
+    listeners['touchmove']({ touches: [touchMove], changedTouches: [touchMove], preventDefault: vi.fn() });
+
     inputManager.update(0);
     expect(inputManager.getInput().x).toBeCloseTo(0.8);
     expect(inputManager.getInput().y).toBeCloseTo(0.4);
 
-    listeners['mouseup'](new MouseEvent('mouseup'));
+    // Touch end
+    listeners['touchend']({ touches: [], changedTouches: [touchMove], target: document.body });
+
     // Small decay step
     inputManager.update(0.1);
     const pos = inputManager.getInput();
@@ -327,7 +326,8 @@ describe('InputManager', () => {
     
     // Should start decaying
     inputManager.update(0.1);
-    expect(inputManager.getInput().x).toBeGreaterThan(-1);
+    // Mouse input does not decay
+    expect(inputManager.getInput().x).toBe(-1);
   });
 
   it('reports isFiring only when touch is on fire button', () => {
@@ -362,7 +362,7 @@ describe('InputManager', () => {
     expect(inputManager.getInput().isFiring).toBe(false);
   });
 
-  it('ignores clicks on other UI elements', () => {
+  it('ignores clicks on other UI elements but allows mouse look', () => {
     const pauseButton = document.createElement('button');
     document.body.appendChild(pauseButton);
 
@@ -372,11 +372,10 @@ describe('InputManager', () => {
 
     expect(inputManager.getInput().isFiring).toBe(false);
     
-    // Check dragging state indirectly (update would change input if dragging)
-    // If not dragging, update shouldn't move input if mouse moves
+    // Mouse move should still update input (Mouse Look) even if clicked on UI
     listeners['mousemove'](new MouseEvent('mousemove', { clientX: 0, clientY: 0 }));
     inputManager.update(0);
-    expect(inputManager.getInput().x).toBe(0);
+    expect(inputManager.getInput().x).toBe(-1);
 
     document.body.removeChild(pauseButton);
   });

--- a/src/input.ts
+++ b/src/input.ts
@@ -21,6 +21,7 @@ export class InputManager {
   private useRelativeInput: boolean = false;
   private pointerAnchor: THREE.Vector2 = new THREE.Vector2(0, 0);
   private fireButton: HTMLElement | null = null;
+  private lastInputType: 'mouse' | 'touch' = 'mouse';
   
   private handleKeyDown = (event: KeyboardEvent) => {
     if (event.code === 'Space') {
@@ -68,11 +69,12 @@ export class InputManager {
   };
 
   private handleMouseMove = (event: MouseEvent) => {
-    if (!this.isDragging) return;
+    this.lastInputType = 'mouse';
     this.updatePointerInput(event.clientX, event.clientY);
   };
 
   private handleTouchStart = (event: TouchEvent) => {
+    this.lastInputType = 'touch';
     for (let i = 0; i < event.changedTouches.length; i++) {
       const touch = event.changedTouches[i];
       const target = touch.target as HTMLElement;
@@ -207,7 +209,7 @@ export class InputManager {
     this.keyboardInput.y = this.moveTowards(this.keyboardInput.y, this.keyboardTarget.y, step);
 
     // Pointer decay when not dragging
-    if (!this.isDragging) {
+    if (!this.isDragging && this.lastInputType === 'touch') {
       const length = this.pointerInput.length();
       if (length > 1e-6) {
         const step = GameConfig.input.centeringSpeed * dt;

--- a/src/style.css
+++ b/src/style.css
@@ -11,7 +11,7 @@
   font-display: swap;
 }
 
-body { margin: 0; overflow: hidden; background-color: black; }
+body { margin: 0; overflow: hidden; background-color: black; cursor: none; }
 
 #cursor {
   position: absolute;


### PR DESCRIPTION
This PR improves the UX for desktop players by enabling standard "Mouse Look" controls (no longer requiring click-and-drag to aim) and hiding the system cursor for better immersion.

Changes:
- `src/input.ts`: Modified `InputManager` to update input on mouse move without requiring a drag operation, and disabled input decay for mouse interactions (so the crosshair stays where you point it).
- `src/style.css`: Added `cursor: none` to the body to hide the system cursor during gameplay.
- `src/UIManager.ts`: Added `cursor-pointer`, `cursor-auto`, and `cursor-text` classes to UI elements (Debug Panel, Game Over screen, Buttons, Inputs) to ensure the cursor is visible and usable when interacting with menus.
- `src/input.test.ts`: Updated tests to verify that mouse movement updates input without clicking and does not decay when the mouse stops moving. Also updated touch tests to use correct relative coordinate calculations based on `touchRadius`.

This makes the game control much more intuitive on desktop and aligns with standard first-person control schemes.

---
*PR created automatically by Jules for task [11557898517542389350](https://jules.google.com/task/11557898517542389350) started by @gfxblit*