### PR TITLE
🎨 Palette: Improve Game Over screen accessibility and transition

### DIFF
--- a/src/UIManager.ts
+++ b/src/UIManager.ts
@@ -20,8 +20,10 @@ export class UIManager {
   private gameOver!: HTMLElement;
   private debugPanel?: HTMLElement;
   private damageOverlay!: HTMLElement;
+  private restartButton!: HTMLButtonElement;
   private stageButtons?: Map<string, HTMLElement>;
   private lastShields: number;
+  private lastIsGameOver: boolean = false;
   private lastStage: string = '';
   private lastIsDeathStarDestroyed: boolean = false;
   private damageTimeout: TimerHandle | null = null;
@@ -302,6 +304,7 @@ export class UIManager {
     restartBtn.textContent = 'RESTART MISSION';
     restartBtn.setAttribute('aria-label', 'Restart Game');
     restartBtn.onclick = () => window.location.reload();
+    this.restartButton = restartBtn as HTMLButtonElement;
   }
 
   destroy() {
@@ -420,9 +423,15 @@ export class UIManager {
 
     if (state.isGameOver) {
       this.gameOver.classList.remove('hidden');
+      if (!this.lastIsGameOver) {
+        this.gameOver.classList.add('animate-fade-in');
+        this.restartButton?.focus();
+      }
     } else {
       this.gameOver.classList.add('hidden');
+      this.gameOver.classList.remove('animate-fade-in');
     }
+    this.lastIsGameOver = state.isGameOver;
 
     if (this.stageButtons) {
       this.updateStageButtons(state.stage);

--- a/src/style.css
+++ b/src/style.css
@@ -68,12 +68,21 @@ body { margin: 0; overflow: hidden; background-color: black; }
   100% { transform: scale(1); filter: brightness(1); }
 }
 
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 .animate-damage-flash {
   animation: damage-flash var(--ui-damage-flash-duration, 0.15s) ease-out forwards;
 }
 
 .animate-shield-impact {
   animation: shield-impact var(--ui-damage-flash-duration, 0.15s) ease-out forwards;
+}
+
+.animate-fade-in {
+  animation: fadeIn 0.5s ease-out forwards;
 }
 
 .debug-minimized {

--- a/src/ui_ux.test.ts
+++ b/src/ui_ux.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { UIManager } from './UIManager';
+import { GameState, state } from './state';
+import { GameConfig } from './config';
+
+describe('UIManager UX Improvements', () => {
+  let uiManager: UIManager;
+  let mockState: GameState;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Reset singleton state
+    state.debug = false;
+    state.isSmartAI = true;
+    state.stageManager = null;
+
+    // Setup mock state
+    mockState = {
+      score: 1234,
+      shields: GameConfig.player.maxShields,
+      kills: 0,
+      wave: 2,
+      stage: 'DOGFIGHT',
+      isGameOver: false,
+      player: null,
+      entityManager: null,
+      stageManager: null,
+      viewport: {
+        width: 1024,
+        height: 768,
+        centerX: 512,
+        centerY: 384,
+      },
+      gunColorToggles: [false, false, false, false],
+      debug: false,
+      isSmartAI: true,
+      isModeColoring: false,
+      showChassis: false,
+      canFireTorpedo: false,
+      hasFiredTorpedo: false,
+      isApproachingDeathStar: false,
+      isDeathStarDestroyed: false,
+      debugKillsThreshold: undefined,
+    };
+
+    // Clean up body
+    document.body.innerHTML = '';
+    uiManager = new UIManager();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    uiManager.destroy();
+  });
+
+  it('should set focus to restart button when Game Over screen appears', () => {
+    // Initial update
+    uiManager.update(mockState);
+
+    // Simulate Game Over
+    mockState.isGameOver = true;
+    uiManager.update(mockState);
+
+    const gameOver = document.getElementById('game-over');
+    const restartBtn = gameOver?.querySelector('button');
+
+    expect(document.activeElement).toBe(restartBtn);
+  });
+
+  it('should apply fade-in animation when Game Over screen appears', () => {
+    // Initial update
+    uiManager.update(mockState);
+
+    const gameOver = document.getElementById('game-over');
+    expect(gameOver?.classList.contains('hidden')).toBe(true);
+    expect(gameOver?.classList.contains('animate-fade-in')).toBe(false);
+
+    // Simulate Game Over
+    mockState.isGameOver = true;
+    uiManager.update(mockState);
+
+    expect(gameOver?.classList.contains('hidden')).toBe(false);
+    expect(gameOver?.classList.contains('animate-fade-in')).toBe(true);
+  });
+});


### PR DESCRIPTION
Implemented a micro-UX improvement for the Game Over screen.
1. Added a smooth fade-in animation using CSS keyframes.
2. Automatically sets focus to the "Restart Mission" button when the Game Over screen appears, improving keyboard accessibility.
3. Added unit tests to verify the focus management and class application.

---
*PR created automatically by Jules for task [6666571437388912015](https://jules.google.com/task/6666571437388912015) started by @gfxblit*