### PR TITLE
🛡️ Sentinel: [CRITICAL] Gate debug mode behind environment check

### DIFF
--- a/src/debug_security.test.ts
+++ b/src/debug_security.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { state, initGame } from './state';
+import * as THREE from 'three';
+import * as environment from './environment';
+
+// Mock the environment module
+vi.mock('./environment', () => ({
+  isDev: vi.fn(),
+}));
+
+describe('Debug Security', () => {
+  const mockScene = new THREE.Scene();
+  const mockHudScene = new THREE.Scene();
+
+  // Store original window.location
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // Reset state before each test
+    state.debug = false;
+
+    // Reset mocks
+    vi.resetAllMocks();
+
+    // Mock window.location
+    // Use delete to remove the existing property if it's configurable
+    // happy-dom usually allows this
+    delete (window as any).location;
+    (window as any).location = {
+      search: '',
+      pathname: '/',
+      assign: vi.fn(),
+      reload: vi.fn(),
+      href: 'http://localhost/',
+      origin: 'http://localhost',
+      protocol: 'http:',
+      host: 'localhost',
+      hostname: 'localhost',
+      port: '',
+      hash: ''
+    };
+  });
+
+  afterEach(() => {
+    // Restore window.location
+    (window as any).location = originalLocation;
+  });
+
+  test('Debug mode is ENABLED in DEV environment with ?debug=true', () => {
+    // Setup DEV environment
+    vi.mocked(environment.isDev).mockReturnValue(true);
+
+    // Setup URL
+    (window.location as any).search = '?debug=true';
+    (window.location as any).pathname = '/';
+
+    initGame(mockScene, mockHudScene);
+
+    expect(state.debug).toBe(true);
+  });
+
+  test('Debug mode is DISABLED in PROD environment with ?debug=true', () => {
+    // Setup PROD environment
+    vi.mocked(environment.isDev).mockReturnValue(false);
+
+    // Setup URL
+    (window.location as any).search = '?debug=true';
+    (window.location as any).pathname = '/';
+
+    initGame(mockScene, mockHudScene);
+
+    expect(state.debug).toBe(false);
+  });
+
+  test('Debug mode is ENABLED in PROD environment on PR preview with ?debug=true', () => {
+    // Setup PROD environment
+    vi.mocked(environment.isDev).mockReturnValue(false);
+
+    // Setup URL with PR path
+    (window.location as any).search = '?debug=true';
+    (window.location as any).pathname = '/pr-123/';
+
+    initGame(mockScene, mockHudScene);
+
+    expect(state.debug).toBe(true);
+  });
+
+  test('Debug mode is DISABLED if ?debug=true is missing', () => {
+    // Setup DEV environment
+    vi.mocked(environment.isDev).mockReturnValue(true);
+
+    // Setup URL without debug param
+    (window.location as any).search = '';
+    (window.location as any).pathname = '/';
+
+    initGame(mockScene, mockHudScene);
+
+    expect(state.debug).toBe(false);
+  });
+
+  test('Debug mode is DISABLED if ?debug=false even in DEV', () => {
+    // Setup DEV environment
+    vi.mocked(environment.isDev).mockReturnValue(true);
+
+    // Setup URL
+    (window.location as any).search = '?debug=false';
+    (window.location as any).pathname = '/';
+
+    initGame(mockScene, mockHudScene);
+
+    expect(state.debug).toBe(false);
+  });
+});

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,0 +1,2 @@
+// Environment utilities to allow mocking in tests
+export const isDev = (): boolean => import.meta.env.DEV;

--- a/src/stages/SurfaceStage_Control.test.ts
+++ b/src/stages/SurfaceStage_Control.test.ts
@@ -16,7 +16,7 @@ describe('SurfaceStage Control Stability', () => {
     vi.stubGlobal('window', {
         innerWidth: 1024,
         innerHeight: 768,
-        location: { search: '' }
+        location: { search: '', pathname: '/' }
     });
     
     initGame(scene, new THREE.Scene());

--- a/src/state.ts
+++ b/src/state.ts
@@ -10,6 +10,7 @@ import { Fireball } from './entities/Fireball';
 import { GameConfig } from './config';
 import { EntityManager } from './entities/EntityManager';
 import { StageManager } from './StageManager';
+import { isDev } from './environment';
 
 export type GameStage = 'DOGFIGHT' | 'SURFACE' | 'TRENCH' | 'EXPLOSION';
 
@@ -80,7 +81,11 @@ export const state: GameState = {
 
 export function initGame(worldScene: THREE.Scene, hudScene: THREE.Scene) {
   const urlParams = new URLSearchParams(window.location.search);
-  state.debug = urlParams.get('debug') === 'true';
+  const isDebugParam = urlParams.get('debug') === 'true';
+  const isPrPreview = window.location.pathname.includes('/pr-');
+
+  // Security fix: Only allow debug mode in DEV environment or PR previews
+  state.debug = isDebugParam && (isDev() || isPrPreview);
 
   // Reset core game values
   state.score = 0;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
This PR addresses a security concern where debug features (which can alter game state) were accessible in production builds simply by adding `?debug=true` to the URL.

The fix involves:
1.  Checking `import.meta.env.DEV` (via a new `isDev()` helper) to restrict debug mode to development environments.
2.  Allowing debug mode in PR previews (detected via `/pr-` in the path) to facilitate review.
3.  Adding extensive tests to verify that debug mode is disabled in production even if the URL parameter is present.
4.  Fixing strict type issues by adding `src/vite-env.d.ts`.

---
*PR created automatically by Jules for task [828743912652624494](https://jules.google.com/task/828743912652624494) started by @gfxblit*