### PR TITLE
🎨 Palette: Add ARIA labels to Debug Panel

### DIFF
--- a/src/UIManager.ts
+++ b/src/UIManager.ts
@@ -91,6 +91,7 @@ export class UIManager {
     const toggleBtn = this.createEl('button', 'ml-4 hover:text-white transition-colors font-retro', header);
     toggleBtn.id = 'debug-minimize-toggle';
     toggleBtn.textContent = '[-]';
+    toggleBtn.setAttribute('aria-label', 'Minimize Debug Panel');
 
     const content = this.createEl('div', 'flex flex-col space-y-2', this.debugPanel);
     content.id = 'debug-panel-content';
@@ -98,6 +99,7 @@ export class UIManager {
     toggleBtn.onclick = () => {
       const isMinimized = content.classList.toggle('hidden');
       toggleBtn.textContent = isMinimized ? '[+]' : '[-]';
+      toggleBtn.setAttribute('aria-label', isMinimized ? 'Expand Debug Panel' : 'Minimize Debug Panel');
       this.debugPanel?.classList.toggle('debug-minimized', isMinimized);
       
       // Clean up header when minimized
@@ -156,6 +158,7 @@ export class UIManager {
     this.createEl('div', 'mt-4 mb-2 border-b border-vector-green pb-1', content).textContent = 'KILLS TO ADVANCE';
     const killsInput = this.createEl('input', 'w-full bg-black text-vector-green border border-vector-green px-2 py-1', content) as HTMLInputElement;
     killsInput.id = 'debug-kills-input';
+    killsInput.setAttribute('aria-label', 'Kills to advance threshold');
     killsInput.type = 'number';
     killsInput.min = '0';
     killsInput.placeholder = `Default (${GameConfig.stages.dogfight.killsThreshold})`;
@@ -175,6 +178,7 @@ export class UIManager {
     this.createEl('div', 'mt-4 mb-2 border-b border-vector-green pb-1', content).textContent = 'TURRET SIZE';
     const turretSizeInput = this.createEl('input', 'w-full bg-black text-vector-green border border-vector-green px-2 py-1', content) as HTMLInputElement;
     turretSizeInput.id = 'debug-turret-size-input';
+    turretSizeInput.setAttribute('aria-label', 'Turret mesh size');
     turretSizeInput.type = 'number';
     turretSizeInput.min = '1';
     turretSizeInput.step = '1';
@@ -195,6 +199,7 @@ export class UIManager {
     this.createEl('div', 'mt-4 mb-2 border-b border-vector-green pb-1', content).textContent = 'FIREBALL SIZE';
     const fireballSizeInput = this.createEl('input', 'w-full bg-black text-vector-green border border-vector-green px-2 py-1', content) as HTMLInputElement;
     fireballSizeInput.id = 'debug-fireball-size-input';
+    fireballSizeInput.setAttribute('aria-label', 'Fireball sparkle size');
     fireballSizeInput.type = 'number';
     fireballSizeInput.min = '1';
     fireballSizeInput.step = '1';

--- a/src/UIManager_Accessibility.test.ts
+++ b/src/UIManager_Accessibility.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { UIManager } from './UIManager';
+import { state } from './state';
+
+describe('UIManager Accessibility', () => {
+  let uiManager: UIManager;
+
+  beforeEach(() => {
+    // Clean up document body before each test
+    document.body.innerHTML = '';
+    state.debug = true; // Enable debug mode to show the panel
+
+    // We need to instantiate UIManager which will append elements to the body
+    uiManager = new UIManager();
+  });
+
+  afterEach(() => {
+    uiManager.destroy();
+    state.debug = false;
+  });
+
+  it('should have accessible label for debug panel toggle button', () => {
+    const toggleBtn = document.getElementById('debug-minimize-toggle');
+    expect(toggleBtn).not.toBeNull();
+
+    // Initial state (expanded) - checks if aria-label is set
+    expect(toggleBtn?.getAttribute('aria-label')).toBe('Minimize Debug Panel');
+
+    // Click to minimize
+    if (toggleBtn) {
+      toggleBtn.click();
+      expect(toggleBtn.getAttribute('aria-label')).toBe('Expand Debug Panel');
+
+      // Click to expand
+      toggleBtn.click();
+      expect(toggleBtn.getAttribute('aria-label')).toBe('Minimize Debug Panel');
+    }
+  });
+
+  it('should have accessible labels for debug inputs', () => {
+    const killsInput = document.getElementById('debug-kills-input');
+    const turretSizeInput = document.getElementById('debug-turret-size-input');
+    const fireballSizeInput = document.getElementById('debug-fireball-size-input');
+
+    expect(killsInput).not.toBeNull();
+    expect(turretSizeInput).not.toBeNull();
+    expect(fireballSizeInput).not.toBeNull();
+
+    expect(killsInput?.getAttribute('aria-label')).toBe('Kills to advance threshold');
+    expect(turretSizeInput?.getAttribute('aria-label')).toBe('Turret mesh size');
+    expect(fireballSizeInput?.getAttribute('aria-label')).toBe('Fireball sparkle size');
+  });
+});


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the Debug Panel toggle button and input fields.
🎯 Why: To improve accessibility for screen reader users by providing descriptive labels for interactive elements that previously lacked semantic association.
📸 Before/After: No visual change.
♿ Accessibility:
- Added `aria-label="Minimize/Expand Debug Panel"` to the toggle button.
- Added `aria-label` to "Kills to Advance", "Turret Size", and "Fireball Size" inputs.

---
*PR created automatically by Jules for task [1563189029770495278](https://jules.google.com/task/1563189029770495278) started by @gfxblit*