### PR TITLE
🎨 Palette: Improve Debug Panel Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Manual DOM Manipulation Risks
+**Learning:** The `UIManager` constructs UI elements via direct DOM manipulation (`document.createElement`), which makes it easy to forget accessibility attributes like `aria-label` and `aria-expanded` on interactive elements.
+**Action:** When working on `UIManager`, explicitly check for and add ARIA attributes to any interactive elements created.

--- a/src/UIManager.ts
+++ b/src/UIManager.ts
@@ -91,6 +91,8 @@ export class UIManager {
     const toggleBtn = this.createEl('button', 'ml-4 hover:text-white transition-colors font-retro', header);
     toggleBtn.id = 'debug-minimize-toggle';
     toggleBtn.textContent = '[-]';
+    toggleBtn.setAttribute('aria-label', 'Minimize Debug Panel');
+    toggleBtn.setAttribute('aria-expanded', 'true');
 
     const content = this.createEl('div', 'flex flex-col space-y-2', this.debugPanel);
     content.id = 'debug-panel-content';
@@ -98,6 +100,8 @@ export class UIManager {
     toggleBtn.onclick = () => {
       const isMinimized = content.classList.toggle('hidden');
       toggleBtn.textContent = isMinimized ? '[+]' : '[-]';
+      toggleBtn.setAttribute('aria-label', isMinimized ? 'Expand Debug Panel' : 'Minimize Debug Panel');
+      toggleBtn.setAttribute('aria-expanded', (!isMinimized).toString());
       this.debugPanel?.classList.toggle('debug-minimized', isMinimized);
       
       // Clean up header when minimized

--- a/src/ui_debug_panel_a11y.test.ts
+++ b/src/ui_debug_panel_a11y.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { UIManager } from './UIManager';
+import { state } from './state';
+
+describe('UIManager Debug Panel Accessibility', () => {
+  let uiManager: UIManager;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Reset singleton state
+    state.debug = true;
+
+    // Clean up body
+    document.body.innerHTML = '';
+    uiManager = new UIManager();
+  });
+
+  afterEach(() => {
+    uiManager.destroy();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('should have correct aria attributes on debug toggle button', () => {
+    const minimizeBtn = document.getElementById('debug-minimize-toggle');
+    expect(minimizeBtn).not.toBeNull();
+
+    // Initial state: Expanded
+    expect(minimizeBtn?.getAttribute('aria-label')).toBe('Minimize Debug Panel');
+    expect(minimizeBtn?.getAttribute('aria-expanded')).toBe('true');
+
+    // Toggle to Minimized
+    minimizeBtn?.click();
+    expect(minimizeBtn?.getAttribute('aria-label')).toBe('Expand Debug Panel');
+    expect(minimizeBtn?.getAttribute('aria-expanded')).toBe('false');
+
+    // Toggle back to Expanded
+    minimizeBtn?.click();
+    expect(minimizeBtn?.getAttribute('aria-label')).toBe('Minimize Debug Panel');
+    expect(minimizeBtn?.getAttribute('aria-expanded')).toBe('true');
+  });
+});


### PR DESCRIPTION
💡 What: Added aria-label and aria-expanded attributes to the Debug Panel toggle button.
🎯 Why: Screen reader users could not identify the purpose or state of the toggle button.
📸 Before/After: Visuals unchanged, but accessibility tree now includes "Minimize Debug Panel" / "Expand Debug Panel".
♿ Accessibility: Added dynamic aria-label and aria-expanded attributes.

---
*PR created automatically by Jules for task [7247614383868794433](https://jules.google.com/task/7247614383868794433) started by @gfxblit*