### PR TITLE
⚡ Bolt: Optimize checkTargets allocation

### DIFF
--- a/src/CombatStrategies.ts
+++ b/src/CombatStrategies.ts
@@ -39,29 +39,33 @@ abstract class BaseCombatStrategy implements CombatStrategy {
   protected checkTargets(input: UserInput, camera: THREE.Camera) {
     if (!state.entityManager) return;
 
-    let closestTarget: Targetable | null = null;
-    let closestDist = Infinity;
+    // Use a mutable object to handle closure updates in forEachTarget callback
+    // This avoids TS control flow analysis issues where it assumes captured vars aren't modified
+    const hitResult = {
+      closestTarget: null as Targetable | null,
+      closestDist: Infinity
+    };
     
     camera.getWorldPosition(this.scratchCameraPos);
 
-    for (const target of state.entityManager.getTargets()) {
+    state.entityManager.forEachTarget((target) => {
       // UsegetWorldPosition to get accurate world position regardless of scene graph depth
       const worldPos = target.getWorldPosition(this.tempVector3);
       
       // Only target active, non-exploded entities within max range
       if (!target.isExploded && checkAim(worldPos, input, camera)) {
         const dist = worldPos.distanceTo(this.scratchCameraPos);
-        if (dist < closestDist && dist < this.config.maxRange) {
-          closestDist = dist;
-          closestTarget = target;
+        if (dist < hitResult.closestDist && dist < this.config.maxRange) {
+          hitResult.closestDist = dist;
+          hitResult.closestTarget = target;
         }
       }
-    }
+    });
 
     // Only explode the single closest target that was aimed at
-    if (closestTarget) {
-      closestTarget.explode();
-      addScore(closestTarget.getScore());
+    if (hitResult.closestTarget) {
+      hitResult.closestTarget.explode();
+      addScore(hitResult.closestTarget.getScore());
       addKill();
     }
   }

--- a/src/entities/EntityManager.ts
+++ b/src/entities/EntityManager.ts
@@ -271,6 +271,17 @@ export class EntityManager {
     return [...this.tieFighters, ...this.additionalTargets];
   }
 
+  public forEachTarget(callback: (target: Targetable) => void): void {
+    // Iterate TIE fighters
+    for (let i = 0; i < this.tieFighters.length; i++) {
+      callback(this.tieFighters[i]);
+    }
+    // Iterate additional targets
+    for (let i = 0; i < this.additionalTargets.length; i++) {
+      callback(this.additionalTargets[i]);
+    }
+  }
+
   public removeTarget(target: Targetable): void {
     const index = this.additionalTargets.indexOf(target);
     if (index !== -1) {


### PR DESCRIPTION
💡 What: Replaced O(N) array allocation in `checkTargets` with `forEachTarget` iterator.
🎯 Why: `getTargets()` created a new array spread from `tieFighters` and `additionalTargets` on every call, causing GC pressure during combat.
📊 Impact: Eliminates array allocation for target iteration in the combat loop.
🔬 Measurement: Verify via `src/CombatStrategies.ts` and `src/entities/EntityManager.ts` changes. Tests in `src/CombatStrategies.test.ts` ensure logic remains correct.

---
*PR created automatically by Jules for task [1712197798197963601](https://jules.google.com/task/1712197798197963601) started by @gfxblit*