### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Content Security Policy

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,9 @@
+
+> vibe-wars@1.0.0 dev /app
+> vite
+
+
+  VITE v5.4.21  ready in 258 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data:; font-src 'self' data:;" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vibe Wars</title>
   </head>

--- a/src/csp.test.ts
+++ b/src/csp.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Window } from 'happy-dom';
+
+describe('Content Security Policy', () => {
+  it('should have a CSP meta tag in index.html', () => {
+    const htmlPath = path.join(process.cwd(), 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf-8');
+
+    // Create a new window to parse the HTML
+    const window = new Window();
+    const document = window.document;
+    document.write(html);
+
+    const meta = document.querySelector('meta[http-equiv="Content-Security-Policy"]');
+
+    // It should fail if the meta tag is missing (reproduction)
+    // After fixing, this expectation will be met.
+    // For now, I expect it to be null if I were asserting failure, but the test is designed to verify the fix.
+    // So I will assert that it exists.
+    expect(meta).not.toBeNull();
+
+    if (meta) {
+      const content = meta.getAttribute('content');
+      expect(content).toContain("default-src 'self'");
+      expect(content).toContain("script-src 'self' 'unsafe-inline' 'unsafe-eval'");
+      expect(content).toContain("style-src 'self' 'unsafe-inline'");
+      expect(content).toContain("img-src 'self' data:");
+      expect(content).toContain("font-src 'self' data:");
+      expect(content).toMatch(/connect-src 'self' ws: wss:;?/);
+    }
+  });
+});


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing Content Security Policy (CSP)
🎯 Impact: Without CSP, the application is vulnerable to Cross-Site Scripting (XSS) attacks if an injection vulnerability exists. Malicious scripts could be loaded from external domains.
🔧 Fix: Added a strict CSP meta tag to index.html restricting sources to 'self', with necessary exceptions for Vite development (unsafe-inline, unsafe-eval, ws:).
✅ Verification: Verified with src/csp.test.ts and frontend verification script.

---
*PR created automatically by Jules for task [13331150685317514657](https://jules.google.com/task/13331150685317514657) started by @gfxblit*