### PR TITLE
⚡ Bolt: Reuse Vector2 instances in Laser updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Vector Allocation Churn in Projectiles
+**Learning:** The `Laser` entity was creating 4 new `THREE.Vector2` instances per frame during `updateMeshTransform`. In a bullet-hell style game where lasers are frequent, this creates significant GC pressure.
+**Action:** When implementing projectile or particle systems in Three.js, always use reusable class member vectors (`_tempVec`, `_start`, `_end`) and methods like `.copy()`, `.add()`, `.lerpVectors()` instead of `new THREE.Vector2()` in the update loop.

--- a/src/entities/Laser.ts
+++ b/src/entities/Laser.ts
@@ -10,6 +10,12 @@ export class Laser extends Entity {
   private readonly target2D: THREE.Vector2;
   private readonly color: number;
 
+  // Reusable vectors to reduce GC pressure
+  private readonly _start = new THREE.Vector2();
+  private readonly _end = new THREE.Vector2();
+  private readonly _delta = new THREE.Vector2();
+  private readonly _center = new THREE.Vector2();
+
   constructor(origin2D: THREE.Vector2, target2D: THREE.Vector2, color: number) {
     super();
     this.origin2D = origin2D.clone();
@@ -38,16 +44,17 @@ export class Laser extends Entity {
     const startP = this.progress;
     const endP = Math.min(1.0, this.progress + normBoltLength);
 
-    const start = new THREE.Vector2().lerpVectors(this.origin2D, this.target2D, startP);
-    const end = new THREE.Vector2().lerpVectors(this.origin2D, this.target2D, endP);
+    // Reuse vectors
+    this._start.lerpVectors(this.origin2D, this.target2D, startP);
+    this._end.lerpVectors(this.origin2D, this.target2D, endP);
 
-    const delta = new THREE.Vector2().subVectors(end, start);
-    const length = delta.length();
-    const angle = Math.atan2(delta.y, delta.x);
+    this._delta.subVectors(this._end, this._start);
+    const length = this._delta.length();
+    const angle = Math.atan2(this._delta.y, this._delta.x);
 
     // Position at the center of the bolt segment
-    const center = new THREE.Vector2().lerpVectors(start, end, 0.5);
-    this.mesh.position.set(center.x, center.y, 0);
+    this._center.lerpVectors(this._start, this._end, 0.5);
+    this.mesh.position.set(this._center.x, this._center.y, 0);
     
     // Rotate to align with trajectory
     // Standard PlaneGeometry(1,1) faces +Z, with its 'up' along +Y.


### PR DESCRIPTION
⚡ Bolt: Reuse Vector2 instances in Laser updates

💡 What:
Modified `src/entities/Laser.ts` to reuse `THREE.Vector2` instances (`_start`, `_end`, `_delta`, `_center`) instead of instantiating new ones every frame in the `updateMeshTransform` method.

🎯 Why:
Creating new vector objects every frame for every laser beam generates significant Garbage Collection (GC) pressure, which can cause frame rate stutters, especially in a "bullet hell" style game where many lasers are active simultaneously.

📊 Impact:
Reduces vector allocations by 4 per laser per frame. For 50 active lasers at 60fps, this saves ~12,000 allocations per second.

🔬 Measurement:
Verified with `pnpm test src/entities/Laser.test.ts` to ensure logic remains correct (positions, rotations, scaling) and full suite `pnpm test` for regression testing. The optimization is purely mechanical (GC reduction) and preserves exact mathematical behavior.

---
*PR created automatically by Jules for task [2455474626819608698](https://jules.google.com/task/2455474626819608698) started by @gfxblit*