### PR TITLE
🛡️ Sentinel: Add Content Security Policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss:;" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vibe Wars</title>
   </head>

--- a/src/csp.test.ts
+++ b/src/csp.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { Window } from 'happy-dom';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('Content Security Policy', () => {
+  it('should have a strict CSP meta tag in index.html', () => {
+    // Read index.html from the root of the project
+    const htmlPath = path.resolve(process.cwd(), 'index.html');
+    const html = fs.readFileSync(htmlPath, 'utf-8');
+
+    // Parse the HTML using happy-dom
+    const window = new Window();
+    const document = window.document;
+    document.write(html);
+
+    // Find the CSP meta tag
+    const meta = document.querySelector('meta[http-equiv="Content-Security-Policy"]');
+
+    // Assert it exists
+    expect(meta).not.toBeNull();
+
+    // Get the content attribute
+    const content = meta?.getAttribute('content');
+
+    // Verify the directives
+    expect(content).toBeDefined();
+    expect(content).toContain("default-src 'self'");
+    expect(content).toContain("script-src 'self' 'unsafe-inline' 'unsafe-eval'");
+    expect(content).toContain("style-src 'self' 'unsafe-inline'");
+    expect(content).toContain("img-src 'self' data: blob:");
+    expect(content).toContain("connect-src 'self' ws: wss:");
+  });
+});


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

💡 **Vulnerability:**
The application previously lacked a Content Security Policy (CSP), which is a critical defense-in-depth mechanism against Cross-Site Scripting (XSS) and other code injection attacks. Without CSP, if an attacker could inject a script tag, the browser would execute it.

🎯 **Impact:**
-   **High:** XSS attacks could lead to session hijacking, data theft, or malicious actions performed on behalf of the user.
-   **Medium:** Loading of unauthorized external resources (e.g., tracking pixels, malicious fonts).

🔧 **Fix:**
Added a `<meta>` tag with a defined Content Security Policy to `index.html`.
The policy is configured to be compatible with Vite's development environment (requiring `unsafe-inline` and `unsafe-eval` for scripts) while still restricting the origin of resources to `'self'` and blocking arbitrary external domains.

✅ **Verification:**
-   Created a new test file `src/csp.test.ts` that parses `index.html` and verifies the existence and content of the CSP meta tag.
-   Ran `pnpm test src/csp.test.ts` to confirm the test passes.
-   Ran `pnpm build` to ensure the application builds correctly with the new meta tag.

---
*PR created automatically by Jules for task [3594514941638354575](https://jules.google.com/task/3594514941638354575) started by @gfxblit*