### PR TITLE
Prevent accidental torpedo firing in Trench Mode

### DIFF
--- a/src/CombatStrategies.ts
+++ b/src/CombatStrategies.ts
@@ -118,6 +118,8 @@ export class SurfaceCombatStrategy extends BaseCombatStrategy {
 }
 
 export class TrenchCombatStrategy extends BaseCombatStrategy {
+  private wasFiring: boolean = false;
+
   constructor(config: CombatStrategyConfig) {
     super(config);
   }
@@ -130,10 +132,13 @@ export class TrenchCombatStrategy extends BaseCombatStrategy {
     if (state.stage === 'TRENCH' && state.stageManager) {
       state.canFireTorpedo = state.stageManager.checkExhaustPortHit(input, camera);
       
-      if (input.isFiring && state.canFireTorpedo && !state.hasFiredTorpedo) {
+      // Only fire if button was NOT pressed in previous frame (fresh press)
+      if (input.isFiring && !this.wasFiring && state.canFireTorpedo && !state.hasFiredTorpedo) {
         this.launchTorpedo(input, camera);
         state.hasFiredTorpedo = true;
       }
+
+      this.wasFiring = input.isFiring;
     }
   }
 

--- a/src/CombatSystem.test.ts
+++ b/src/CombatSystem.test.ts
@@ -146,6 +146,8 @@ describe('CombatSystem', () => {
 
     state.stageManager!.reset();
     
+    // Must release fire button to fire again (accidental fire prevention)
+    combatSystem.update(0.01, { ...input, isFiring: false });
     combatSystem.update(0.01, input);
     expect(StateModule.spawnTorpedo).toHaveBeenCalledTimes(2);
   });

--- a/src/CombatSystem_TrenchFiring.test.ts
+++ b/src/CombatSystem_TrenchFiring.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as THREE from 'three';
+import { TrenchCombatStrategy } from './CombatStrategies';
+import { state, initGame } from './state';
+import * as StateModule from './state';
+import { GameConfig } from './config';
+
+// Mock dependencies
+vi.mock('./state', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./state')>();
+  return {
+    ...actual,
+    spawnLasers: vi.fn(),
+    spawnTorpedo: vi.fn(),
+  };
+});
+
+// Mock collision check to simulate aiming at the exhaust port
+vi.mock('./collision', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./collision')>();
+  return {
+    ...actual,
+    checkAim: vi.fn(),
+  };
+});
+
+describe('TrenchCombatStrategy - Firing Logic', () => {
+  let camera: THREE.Camera;
+  let strategy: TrenchCombatStrategy;
+  let checkAimMock: any;
+
+  beforeEach(async () => {
+    // Reset mocks
+    vi.clearAllMocks();
+    
+    // Setup basic game state
+    const scene = new THREE.Scene();
+    const hudScene = new THREE.Scene();
+    initGame(scene, hudScene);
+    
+    state.stage = 'TRENCH';
+    state.stageManager!.reset();
+    
+    // Setup camera
+    camera = new THREE.PerspectiveCamera();
+    camera.updateMatrixWorld();
+    
+    // Setup strategy
+    const strategyConfig = {
+      maxRange: GameConfig.laser.maxRange,
+      fireCooldown: GameConfig.laser.cooldown,
+      fireballCollisionRadiusNDC: GameConfig.fireball.collisionRadiusNDC,
+      fireballPoints: GameConfig.fireball.points,
+      baseForwardSpeed: GameConfig.player.baseForwardSpeed,
+      torpedoSpeedMultiplier: GameConfig.torpedo.speedMultiplier,
+    };
+    strategy = new TrenchCombatStrategy(strategyConfig);
+    
+    // Setup player position near the exhaust port to satisfy range check
+    const { catwalkEndZ, exhaustPortZOffset } = GameConfig.stages.trench;
+    const portZ = catwalkEndZ - exhaustPortZOffset;
+    state.player!.position.set(0, 0, portZ + 10);
+    
+    // Get the mock function for checkAim
+    const collisionModule = await import('./collision');
+    checkAimMock = collisionModule.checkAim;
+    checkAimMock.mockReturnValue(false); // Default to not aiming at port
+  });
+
+  it('PREVENTS firing torpedo if fire button was held BEFORE aiming at port', () => {
+    // 1. Holding fire button, but NOT aiming at port
+    checkAimMock.mockReturnValue(false);
+    let input = { x: 0, y: 0, isFiring: true };
+    strategy.update(0.016, input, camera);
+    
+    expect(state.canFireTorpedo).toBe(false);
+    expect(StateModule.spawnTorpedo).not.toHaveBeenCalled();
+
+    // 2. Still holding fire button, NOW aiming at port
+    checkAimMock.mockReturnValue(true);
+    input = { x: 0, y: 0, isFiring: true };
+    strategy.update(0.016, input, camera);
+    
+    expect(state.canFireTorpedo).toBe(true);
+    // Should not fire because the button was held down before aiming
+    expect(StateModule.spawnTorpedo).not.toHaveBeenCalled(); 
+  });
+
+  it('ALLOWS firing torpedo if fire button is pressed AFTER aiming at port', () => {
+    // 1. Aiming at port, NOT firing
+    checkAimMock.mockReturnValue(true);
+    let input = { x: 0, y: 0, isFiring: false };
+    strategy.update(0.016, input, camera);
+    
+    expect(state.canFireTorpedo).toBe(true);
+    expect(StateModule.spawnTorpedo).not.toHaveBeenCalled();
+
+    // 2. Still aiming at port, NOW firing (fresh press)
+    input = { x: 0, y: 0, isFiring: true };
+    strategy.update(0.016, input, camera);
+
+    expect(state.canFireTorpedo).toBe(true);
+    expect(StateModule.spawnTorpedo).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- Implemented a rising edge check for the fire button in `TrenchCombatStrategy` to require a fresh press when locking onto the exhaust port.
- Added `wasFiring` state to `TrenchCombatStrategy`.
- Added reproduction test case `src/CombatSystem_TrenchFiring.test.ts`.
- Updated `src/CombatSystem.test.ts` to simulate button release on reset.

Closes https://github.com/gfxblit/vibe-wars/issues/150