### PR TITLE
feat(surface): remove damage from floor collisions in SurfaceStage

### DIFF
--- a/src/stages/SurfaceStage.test.ts
+++ b/src/stages/SurfaceStage.test.ts
@@ -97,7 +97,7 @@ describe('SurfaceStage', () => {
     expect(goToNextStage).toHaveBeenCalled();
   });
 
-  it('should damage player if they hit the floor', () => {
+  it('should NOT damage player if they hit the floor', () => {
     stage = new SurfaceStage(scene, goToNextStage);
     const player = state.player as Player;
     
@@ -106,7 +106,7 @@ describe('SurfaceStage', () => {
     player.position.y = GameConfig.stages.surface.floorY - GameConfig.stages.surface.floorClampBuffer;
     
     stage.update(0.1, player, mockCamera);
-    expect(takeDamage).toHaveBeenCalledWith(GameConfig.stages.surface.collisionDamage);
+    expect(takeDamage).not.toHaveBeenCalled();
     // Should bump player up by the bounce amount
     expect(player.position.y).toBe(GameConfig.stages.surface.floorY + GameConfig.stages.surface.floorBounce);
   });

--- a/src/stages/SurfaceStage.ts
+++ b/src/stages/SurfaceStage.ts
@@ -56,7 +56,6 @@ export class SurfaceStage extends Stage {
     const { floorHit, towerHit } = this.surface.checkCollisions(playerBox, player.position);
 
     if (floorHit) { 
-        takeDamage(GameConfig.stages.surface.collisionDamage);
         // Bounce player up to avoid instant death loop or getting stuck
         player.position.y = GameConfig.stages.surface.floorY + GameConfig.stages.surface.floorBounce;
     }


### PR DESCRIPTION
- Hitting the floor no longer calls takeDamage
- Player still bounces to floorBounce height on collision
- Tower collisions still cause damage
- Updated tests to reflect the change

Closes #170

Closes https://github.com/gfxblit/vibe-wars/issues/170