### PR TITLE
🛡️ Sentinel: [HIGH] Add Content Security Policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Security: CSP configured for Vite dev mode (requires unsafe-inline/eval) -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' ws: wss:;">
     <title>Vibe Wars</title>
   </head>
   <body>

--- a/src/csp.test.ts
+++ b/src/csp.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { Window } from 'happy-dom';
+
+describe('Content Security Policy', () => {
+  it('should be present in index.html with correct directives', () => {
+    // Read index.html from project root
+    const htmlPath = path.resolve(process.cwd(), 'index.html');
+    const htmlContent = fs.readFileSync(htmlPath, 'utf-8');
+
+    // Parse HTML
+    const window = new Window();
+    const document = window.document;
+    document.write(htmlContent);
+
+    // Check for meta tag
+    const meta = document.querySelector('meta[http-equiv="Content-Security-Policy"]');
+    expect(meta).not.toBeNull();
+
+    const content = meta?.getAttribute('content') || '';
+
+    // Verify critical directives
+    expect(content).toContain("default-src 'self'");
+    expect(content).toContain("script-src 'self' 'unsafe-inline' 'unsafe-eval'"); // Vite dev requirement
+    expect(content).toContain("style-src 'self' 'unsafe-inline'"); // Vite CSS injection
+    expect(content).toContain("connect-src 'self' ws: wss:"); // Vite HMR
+    expect(content).toContain("img-src 'self' data:"); // Local images
+    expect(content).toContain("font-src 'self' data:"); // Local fonts
+  });
+});


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Add Content Security Policy

🚨 Severity: HIGH
💡 Vulnerability: Missing Content Security Policy (CSP) allowed potential XSS and object injection.
🎯 Impact: Attackers could inject malicious scripts or resources if an XSS vulnerability were found elsewhere.
🔧 Fix: Added a strict CSP meta tag to index.html, allowing only self-hosted resources and necessary Vite dev tools (unsafe-inline/eval, ws:).
✅ Verification: Added src/csp.test.ts to enforce CSP presence. Verified frontend loads without console errors using Playwright.

---
*PR created automatically by Jules for task [14844492591506649274](https://jules.google.com/task/14844492591506649274) started by @gfxblit*