### PR TITLE
🎨 Palette: Add Start Screen overlay

### DIFF
--- a/src/ExplosionStageTitle.test.ts
+++ b/src/ExplosionStageTitle.test.ts
@@ -25,6 +25,7 @@ describe('ExplosionStageTitle', () => {
       kills: 0,
       wave: 1,
       stage: 'DOGFIGHT',
+      isGameStarted: true,
       isGameOver: false,
       player: null,
       entityManager: null,

--- a/src/UIManager.ts
+++ b/src/UIManager.ts
@@ -19,6 +19,7 @@ export class UIManager {
   private gameOver!: HTMLElement;
   private damageOverlay!: HTMLElement;
   private restartButton!: HTMLButtonElement;
+  private startScreen!: HTMLElement;
   private lastShields: number;
   private lastIsGameOver: boolean = false;
   private lastStage: string = '';
@@ -66,6 +67,7 @@ export class UIManager {
     this.torpedoReadyValue.textContent = 'TORPEDO READY';
 
     this.createGameOverOverlay();
+    this.createStartScreen();
 
     // Damage overlay should be on top of other HUD elements for maximum impact
     this.damageOverlay = this.createEl('div', 'fixed inset-0 bg-vector-red opacity-0 pointer-events-none z-50', this.hud);
@@ -134,6 +136,31 @@ export class UIManager {
     restartBtn.setAttribute('aria-label', 'Restart Game');
     restartBtn.onclick = () => window.location.reload();
     this.restartButton = restartBtn as HTMLButtonElement;
+  }
+
+  private createStartScreen() {
+    this.startScreen = this.createEl('div', 'fixed inset-0 flex flex-col items-center justify-center bg-black bg-opacity-90 z-50 pointer-events-auto', this.hud);
+    this.startScreen.id = 'start-screen';
+
+    const title = this.createEl('div', 'text-vector-yellow text-8xl font-retro mb-4 text-center', this.startScreen);
+    title.textContent = 'VIBE WARS';
+
+    const subtitle = this.createEl('div', 'text-vector-red text-4xl font-retro mb-12 text-center', this.startScreen);
+    subtitle.textContent = 'A NEW HOPE';
+
+    const instructions = this.createEl('div', 'text-vector-green text-xl font-retro mb-12 text-center max-w-2xl leading-relaxed', this.startScreen);
+    instructions.innerHTML = 'PILOT THE X-WING<br>MOUSE/TOUCH TO AIM & TURN<br>CLICK/TAP TO FIRE';
+
+    const startBtn = this.createEl('button', 'px-12 py-4 border-2 border-vector-green text-vector-green hover:bg-vector-green hover:text-black font-retro text-3xl transition-colors focus:outline-none focus:ring-2 focus:ring-vector-green focus:ring-offset-2 focus:ring-offset-black cursor-pointer', this.startScreen);
+    startBtn.textContent = 'START MISSION';
+    startBtn.setAttribute('aria-label', 'Start Game');
+    startBtn.onclick = () => {
+      state.isGameStarted = true;
+      this.startScreen.classList.add('hidden');
+    };
+
+    // Auto-focus the start button for accessibility
+    setTimeout(() => startBtn.focus(), 100);
   }
 
   destroy() {
@@ -262,6 +289,12 @@ export class UIManager {
       this.gameOver.classList.remove('animate-fade-in');
     }
     this.lastIsGameOver = state.isGameOver;
+
+    if (state.isGameStarted) {
+      this.startScreen.classList.add('hidden');
+    } else {
+      this.startScreen.classList.remove('hidden');
+    }
 
     if (state.isApproachingDeathStar) {
       this.instructionValue.textContent = 'APPROACH DEATH STAR';

--- a/src/UIManager_StartScreen.test.ts
+++ b/src/UIManager_StartScreen.test.ts
@@ -1,0 +1,62 @@
+import { expect, test, beforeEach, describe } from 'vitest';
+import { UIManager } from './UIManager';
+import { state, initGame } from './state';
+import * as THREE from 'three';
+
+describe('UIManager Start Screen', () => {
+  let uiManager: UIManager;
+
+  beforeEach(() => {
+    // Reset state
+    state.debug = false;
+    state.isGameStarted = false;
+
+    // Setup DOM
+    document.body.innerHTML = '';
+
+    // Initialize game state (required for UIManager)
+    initGame(new THREE.Scene(), new THREE.Scene());
+
+    uiManager = new UIManager();
+  });
+
+  test('Start screen is created and visible initially', () => {
+    const startScreen = document.getElementById('start-screen');
+    expect(startScreen).toBeTruthy();
+    expect(startScreen!.classList.contains('hidden')).toBe(false);
+  });
+
+  test('Start screen contains correct title and button', () => {
+    const startScreen = document.getElementById('start-screen');
+    expect(startScreen!.textContent).toContain('VIBE WARS');
+    expect(startScreen!.textContent).toContain('A NEW HOPE');
+
+    const button = startScreen!.querySelector('button');
+    expect(button).toBeTruthy();
+    expect(button!.textContent).toBe('START MISSION');
+    expect(button!.getAttribute('aria-label')).toBe('Start Game');
+  });
+
+  test('Clicking Start Mission button updates state and hides screen', () => {
+    const startScreen = document.getElementById('start-screen');
+    const button = startScreen!.querySelector('button') as HTMLButtonElement;
+
+    expect(state.isGameStarted).toBe(false);
+
+    button.click();
+
+    expect(state.isGameStarted).toBe(true);
+
+    // We need to call update to reflect the change in UI
+    uiManager.update(state);
+    expect(startScreen!.classList.contains('hidden')).toBe(true);
+  });
+
+  test('Start screen is hidden if game is already started', () => {
+    state.isGameStarted = true;
+    uiManager.update(state);
+
+    const startScreen = document.getElementById('start-screen');
+    expect(startScreen!.classList.contains('hidden')).toBe(true);
+  });
+});

--- a/src/UIManager_Timeout.test.ts
+++ b/src/UIManager_Timeout.test.ts
@@ -19,6 +19,7 @@ describe('UIManager Timeout Management', () => {
       kills: 0,
       wave: 1,
       stage: 'DOGFIGHT',
+      isGameStarted: true,
       isGameOver: false,
       player: null,
       entityManager: null,

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,9 @@ function animate(time: number) {
   inputManager.update(deltaTime)
   const input = inputManager.getInput()
 
-  gameSystem.update(deltaTime, input)
+  if (state.isGameStarted) {
+    gameSystem.update(deltaTime, input)
+  }
 
   cursor.update(input)
   uiManager.update(state)

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -24,6 +24,7 @@ describe('Game State', () => {
     expect(state.shields).toBe(6)
     expect(state.kills).toBe(0)
     expect(state.stage).toBe('DOGFIGHT')
+    expect(state.isGameStarted).toBe(false)
     expect(state.player).toBeInstanceOf(Player)
     expect(state.entityManager!.getTieFighters()[0]).toBeInstanceOf(TieFighter)
     expect(state.entityManager!.getLasers()).toEqual([]);

--- a/src/state.ts
+++ b/src/state.ts
@@ -26,6 +26,7 @@ export interface GameState {
   kills: number;
   wave: number;
   stage: GameStage;
+  isGameStarted: boolean;
   isGameOver: boolean;
   player: Player | null;
   entityManager: EntityManager | null;
@@ -61,6 +62,7 @@ export const state: GameState = {
   kills: 0,
   wave: 1,
   stage: 'DOGFIGHT',
+  isGameStarted: false,
   isGameOver: false,
   player: null,
   entityManager: null,
@@ -102,6 +104,7 @@ export function initGame(worldScene: THREE.Scene, hudScene: THREE.Scene) {
   state.kills = 0;
   state.wave = 1;
   state.stage = 'DOGFIGHT';
+  state.isGameStarted = false;
   state.isGameOver = false;
   state.gunColorToggles = GameConfig.laser.offsets.map(() => false);
   state.canFireTorpedo = false;

--- a/src/ui.test.ts
+++ b/src/ui.test.ts
@@ -22,6 +22,7 @@ describe('UIManager', () => {
       kills: 0,
       wave: 2,
       stage: 'DOGFIGHT',
+      isGameStarted: true,
       isGameOver: false,
       player: null,
       entityManager: null,

--- a/src/ui_distance.test.ts
+++ b/src/ui_distance.test.ts
@@ -19,6 +19,7 @@ describe('UIManager - Distance Countdown', () => {
       kills: 0,
       wave: 1,
       stage: 'TRENCH',
+      isGameStarted: true,
       isGameOver: false,
       player: {
         position: new THREE.Vector3(0, 0, 0)

--- a/src/ui_instruction.test.ts
+++ b/src/ui_instruction.test.ts
@@ -16,6 +16,7 @@ describe('UIManager Instructions', () => {
       kills: 0,
       wave: 1,
       stage: 'DOGFIGHT',
+      isGameStarted: true,
       isGameOver: false,
       player: null,
       entityManager: null,

--- a/src/ui_ux.test.ts
+++ b/src/ui_ux.test.ts
@@ -21,6 +21,7 @@ describe('UIManager UX Improvements', () => {
       kills: 0,
       wave: 2,
       stage: 'DOGFIGHT',
+      isGameStarted: true,
       isGameOver: false,
       player: null,
       entityManager: null,


### PR DESCRIPTION
Implemented a "Start Screen" overlay that greets the user with "VIBE WARS: A NEW HOPE" and a "START MISSION" button. The game loop (logic update) is paused until the user clicks the start button, while the rendering loop continues to show the static scene (providing a nice "attract mode" feel). This prevents the game from starting abruptly and allows the user to prepare. Added comprehensive tests for the new UI and state logic.

---
*PR created automatically by Jules for task [11332278701848574385](https://jules.google.com/task/11332278701848574385) started by @gfxblit*