### PR TITLE
🎨 Palette: Add ARIA live regions to Game HUD

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Accessibility for Game HUDs
+**Learning:** Game HUDs update dynamic text (instructions, alerts) frequently, but without `aria-live` regions, these updates are invisible to screen readers. Adding `role="status"` and `aria-live="polite"` makes these updates accessible without disrupting gameplay flow.
+**Action:** Always audit dynamic text containers in game UIs for `aria-live` attributes to ensure critical game information is announced.

--- a/src/UIManager.ts
+++ b/src/UIManager.ts
@@ -57,12 +57,21 @@ export class UIManager {
     this.distanceValue.id = 'distance-value';
     this.destructionValue = this.createEl('div', 'text-vector-red text-3xl font-bold text-center hidden animate-pulse', centerArea);
     this.destructionValue.id = 'destruction-value';
+    this.destructionValue.setAttribute('role', 'status');
+    this.destructionValue.setAttribute('aria-live', 'assertive');
     this.destructionValue.textContent = 'DEATH STAR DESTROYED';
     this.greatShotValue = this.createEl('div', 'text-vector-yellow text-2xl font-bold text-center hidden', centerArea);
     this.greatShotValue.id = 'great-shot-value';
+    this.greatShotValue.setAttribute('role', 'status');
+    this.greatShotValue.setAttribute('aria-live', 'polite');
     this.greatShotValue.textContent = 'GREAT SHOT KID!';
     this.instructionValue = this.createEl('div', 'text-vector-green text-xl text-center hidden', centerArea);
+    this.instructionValue.id = 'instruction-value';
+    this.instructionValue.setAttribute('role', 'status');
+    this.instructionValue.setAttribute('aria-live', 'polite');
     this.torpedoReadyValue = this.createEl('div', 'text-vector-red text-2xl font-bold hidden animate-pulse', centerArea);
+    this.torpedoReadyValue.id = 'torpedo-ready-value';
+    this.torpedoReadyValue.setAttribute('role', 'alert');
     this.torpedoReadyValue.textContent = 'TORPEDO READY';
 
     this.createGameOverOverlay();
@@ -125,8 +134,12 @@ export class UIManager {
   private createGameOverOverlay() {
     this.gameOver = this.createEl('div', 'fixed inset-0 flex flex-col items-center justify-center bg-black bg-opacity-70 hidden z-50 pointer-events-auto', this.hud);
     this.gameOver.id = 'game-over';
+    this.gameOver.setAttribute('role', 'alertdialog');
+    this.gameOver.setAttribute('aria-modal', 'true');
+    this.gameOver.setAttribute('aria-labelledby', 'game-over-title');
 
     const text = this.createEl('div', 'text-vector-red text-6xl font-retro animate-pulse mb-8', this.gameOver);
+    text.id = 'game-over-title';
     text.textContent = 'GAME OVER';
 
     const restartBtn = this.createEl('button', 'px-8 py-3 border-2 border-vector-green text-vector-green hover:bg-vector-green hover:text-black font-retro text-2xl transition-colors focus:outline-none focus:ring-2 focus:ring-vector-green focus:ring-offset-2 focus:ring-offset-black', this.gameOver);

--- a/src/UIManager_LiveRegions.test.ts
+++ b/src/UIManager_LiveRegions.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { UIManager } from './UIManager';
+import { state } from './state';
+
+describe('UIManager Live Regions', () => {
+  let uiManager: UIManager;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    state.debug = false; // Disable debug UI for cleaner DOM
+    document.body.innerHTML = '';
+    uiManager = new UIManager();
+  });
+
+  afterEach(() => {
+    uiManager.destroy();
+    vi.restoreAllMocks();
+  });
+
+  it('should have correct ARIA attributes on instruction elements', () => {
+    const instructionEl = document.getElementById('instruction-value');
+    expect(instructionEl).not.toBeNull();
+    expect(instructionEl?.getAttribute('role')).toBe('status');
+    expect(instructionEl?.getAttribute('aria-live')).toBe('polite');
+
+    // Simulate a state change to verify text content update doesn't remove attributes
+    state.stage = 'DOGFIGHT';
+    uiManager.update(state);
+
+    expect(instructionEl?.textContent).toBe('CLEAR THE SECTOR OF TIE FIGHTERS');
+    expect(instructionEl?.getAttribute('role')).toBe('status');
+  });
+
+  it('should have correct ARIA attributes on critical events', () => {
+    const destructionEl = document.getElementById('destruction-value');
+    expect(destructionEl).not.toBeNull();
+    expect(destructionEl?.getAttribute('role')).toBe('status');
+    expect(destructionEl?.getAttribute('aria-live')).toBe('assertive');
+
+    const greatShotEl = document.getElementById('great-shot-value');
+    expect(greatShotEl).not.toBeNull();
+    expect(greatShotEl?.getAttribute('role')).toBe('status');
+    expect(greatShotEl?.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('should have alert role on torpedo ready indicator', () => {
+    const torpedoEl = document.getElementById('torpedo-ready-value');
+    expect(torpedoEl).not.toBeNull();
+    expect(torpedoEl?.getAttribute('role')).toBe('alert');
+
+    // Verify it becomes visible when ready
+    state.stage = 'TRENCH';
+    state.canFireTorpedo = true;
+    uiManager.update(state);
+
+    expect(torpedoEl?.classList.contains('hidden')).toBe(false);
+  });
+
+  it('should have alertdialog role on game over screen', () => {
+    const gameOverEl = document.getElementById('game-over');
+    expect(gameOverEl).not.toBeNull();
+    expect(gameOverEl?.getAttribute('role')).toBe('alertdialog');
+    expect(gameOverEl?.getAttribute('aria-modal')).toBe('true');
+    expect(gameOverEl?.getAttribute('aria-labelledby')).toBe('game-over-title');
+
+    const titleEl = document.getElementById('game-over-title');
+    expect(titleEl).not.toBeNull();
+    expect(titleEl?.textContent).toBe('GAME OVER');
+  });
+});


### PR DESCRIPTION
This PR improves the accessibility of the game HUD by adding ARIA live regions and roles to dynamic text elements. This ensures that screen reader users receive critical game updates (like instructions, torpedo readiness, and game over state) which were previously only conveyed visually.

Changes:
- `src/UIManager.ts`: Added `role` and `aria-live` attributes to `instructionValue`, `destructionValue`, `greatShotValue`, `torpedoReadyValue`, and `gameOver` elements. Added IDs to support testing and labeling.
- `src/UIManager_LiveRegions.test.ts`: Added new test file to verify accessibility attributes.
- `.Jules/palette.md`: Recorded learning about game HUD accessibility.

---
*PR created automatically by Jules for task [17038297602152291505](https://jules.google.com/task/17038297602152291505) started by @gfxblit*