### PR TITLE
⚡ Bolt: Optimize target iteration in CombatStrategies

### DIFF
--- a/src/CombatStrategies.ts
+++ b/src/CombatStrategies.ts
@@ -39,13 +39,16 @@ abstract class BaseCombatStrategy implements CombatStrategy {
   protected checkTargets(input: UserInput, camera: THREE.Camera) {
     if (!state.entityManager) return;
 
-    let closestTarget: Targetable | null = null;
-    let closestDist = Infinity;
+    // Use a mutable object to capture results in the callback, satisfying TS control flow analysis
+    const result = {
+      closestTarget: null as Targetable | null,
+      closestDist: Infinity
+    };
     
     camera.getWorldPosition(this.scratchCameraPos);
 
-    for (const target of state.entityManager.getTargets()) {
-      if (target.isExploded) continue;
+    state.entityManager.forEachTarget((target) => {
+      if (target.isExploded) return;
 
       // Check all possible target points if the entity provides them, otherwise use base world position
       const targetPoints = target.getTargetPositions ? 
@@ -65,16 +68,16 @@ abstract class BaseCombatStrategy implements CombatStrategy {
         }
       }
 
-      if (isHit && hitDist < closestDist && hitDist < this.config.maxRange) {
-        closestDist = hitDist;
-        closestTarget = target;
+      if (isHit && hitDist < result.closestDist && hitDist < this.config.maxRange) {
+        result.closestDist = hitDist;
+        result.closestTarget = target;
       }
-    }
+    });
 
     // Only explode the single closest target that was aimed at
-    if (closestTarget) {
-      closestTarget.explode();
-      addScore(closestTarget.getScore());
+    if (result.closestTarget) {
+      result.closestTarget.explode();
+      addScore(result.closestTarget.getScore());
       addKill();
     }
   }

--- a/src/entities/EntityManager.ts
+++ b/src/entities/EntityManager.ts
@@ -288,6 +288,17 @@ export class EntityManager {
     return [...this.tieFighters, ...this.additionalTargets];
   }
 
+  public forEachTarget(callback: (target: Targetable) => void): void {
+    // Iterate TIE fighters
+    for (let i = 0; i < this.tieFighters.length; i++) {
+      callback(this.tieFighters[i]);
+    }
+    // Iterate additional targets
+    for (let i = 0; i < this.additionalTargets.length; i++) {
+      callback(this.additionalTargets[i]);
+    }
+  }
+
   public removeTarget(target: Targetable): void {
     const index = this.additionalTargets.indexOf(target);
     if (index !== -1) {

--- a/src/entities/EntityManager_Optimization.test.ts
+++ b/src/entities/EntityManager_Optimization.test.ts
@@ -1,0 +1,48 @@
+import { expect, test, describe, beforeEach } from 'vitest'
+import * as THREE from 'three'
+import { EntityManager } from './EntityManager'
+import { Targetable } from './Entity'
+import { initGame, state } from '../state'
+
+describe('EntityManager Optimization', () => {
+  let scene: THREE.Scene;
+  let hudScene: THREE.Scene;
+  let entityManager: EntityManager;
+
+  beforeEach(() => {
+    scene = new THREE.Scene();
+    hudScene = new THREE.Scene();
+    initGame(scene, hudScene);
+    entityManager = state.entityManager!;
+  })
+
+  test('forEachTarget should iterate over both TieFighters and additional targets', () => {
+    entityManager.clear();
+
+    // Add a TieFighter
+    entityManager.spawnTieFighter(false);
+    expect(entityManager.getTieFighters().length).toBe(1);
+
+    // Add a mock target
+    const mockTarget: Targetable = {
+      position: new THREE.Vector3(),
+      getWorldPosition: () => new THREE.Vector3(),
+      isExploded: false,
+      explode: () => {},
+      getScore: () => 100
+    };
+    entityManager.addTarget(mockTarget);
+
+    // Check baseline
+    expect(entityManager.getTargets().length).toBe(2);
+
+    const visited: Targetable[] = [];
+    entityManager.forEachTarget((target) => {
+        visited.push(target);
+    });
+
+    expect(visited.length).toBe(2);
+    expect(visited).toContain(entityManager.getTieFighters()[0]);
+    expect(visited).toContain(mockTarget);
+  });
+});


### PR DESCRIPTION
⚡ Bolt: Optimize target iteration in CombatStrategies

💡 What:
Implemented `EntityManager.forEachTarget(callback)` to iterate over `tieFighters` and `additionalTargets` directly without creating a new combined array. Updated `CombatStrategies.ts` to use this method.

🎯 Why:
The previous implementation used `[...this.tieFighters, ...this.additionalTargets]`, which allocated a new array every time `checkTargets` was called (frequently during combat). This caused unnecessary Garbage Collection pressure.

📊 Impact:
Reduces array allocations in the hot path of the combat loop. For N targets, it saves one array allocation of size N per check.

🔬 Measurement:
Verified with `src/entities/EntityManager_Optimization.test.ts` which ensures `forEachTarget` correctly visits all entities. Existing tests pass, ensuring no regressions in targeting logic.

---
*PR created automatically by Jules for task [68871303295369748](https://jules.google.com/task/68871303295369748) started by @gfxblit*