### PR TITLE
🛡️ Sentinel: Fix insecure Vite Host header validation

### DIFF
--- a/src/vite-config.test.ts
+++ b/src/vite-config.test.ts
@@ -2,12 +2,10 @@ import { describe, it, expect } from 'vitest';
 import config from '../vite.config';
 
 describe('Vite Configuration', () => {
-  it('allows external hosts in server configuration', () => {
-    // We expect the server configuration to exist and allowedHosts to be true
-    // Casting to any because the type definition might not explicitly include allowedHosts 
-    // depending on the Vite version, but it is a valid config option.
+  it('does not bypass host header validation (secure default)', () => {
+    // We expect the server configuration to not override allowedHosts
     const serverConfig = (config as any).server;
     expect(serverConfig).toBeDefined();
-    expect(serverConfig.allowedHosts).toBe(true);
+    expect(serverConfig.allowedHosts).toBeUndefined();
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   base: './',
   server: {
-    allowedHosts: true,
+    // allowedHosts: true, // Removed to restore secure default behavior (Host header validation)
   },
   test: {
     environment: 'happy-dom',


### PR DESCRIPTION
**Vulnerability:** The Vite development server was configured with `allowedHosts: true`, which disables Host header validation.
**Impact:** This configuration could allow a malicious website to access the development server via a DNS rebinding attack if a developer visited it while the server was running.
**Fix:** Removed the insecure configuration to restore default Host header validation. Updated tests to verify the secure state.

---
*PR created automatically by Jules for task [5214198991893747096](https://jules.google.com/task/5214198991893747096) started by @gfxblit*