### PR TITLE
🛡️ Sentinel: Enforce strict CSP in production builds

### DIFF
--- a/src/vite-config.test.ts
+++ b/src/vite-config.test.ts
@@ -2,11 +2,16 @@ import { describe, it, expect } from 'vitest';
 import config from '../vite.config';
 
 describe('Vite Configuration', () => {
-  it('allows external hosts in server configuration', () => {
+  it('allows external hosts in server configuration', async () => {
+    let resolvedConfig = config;
+    if (typeof config === 'function') {
+      resolvedConfig = await (config as any)({ command: 'serve', mode: 'development' });
+    }
+
     // We expect the server configuration to exist and allowedHosts to be true
     // Casting to any because the type definition might not explicitly include allowedHosts 
     // depending on the Vite version, but it is a valid config option.
-    const serverConfig = (config as any).server;
+    const serverConfig = (resolvedConfig as any).server;
     expect(serverConfig).toBeDefined();
     expect(serverConfig.allowedHosts).toBe(true);
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,45 @@
-import { defineConfig } from 'vite';
+import { defineConfig, Plugin } from 'vite';
 
-export default defineConfig({
-  base: './',
-  server: {
-    allowedHosts: true,
-  },
-  test: {
-    environment: 'happy-dom',
-  },
+export default defineConfig(({ command }) => {
+  const plugins: Plugin[] = [];
+
+  if (command === 'build') {
+    plugins.push({
+      name: 'security-headers',
+      transformIndexHtml(html) {
+        // Strict CSP: Removes 'unsafe-eval'/'unsafe-inline' and 'ws:'/'wss:'
+        const strictCsp = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self';";
+
+        // Remove any existing CSP meta tag to avoid duplication/conflicts
+        const cspRegex = /<meta\s+[^>]*http-equiv=["']Content-Security-Policy["'][^>]*>/i;
+        const cleanedHtml = html.replace(cspRegex, '');
+
+        // Return the cleaned HTML and inject the strict CSP meta tag
+        return {
+          html: cleanedHtml,
+          tags: [
+            {
+              tag: 'meta',
+              attrs: {
+                'http-equiv': 'Content-Security-Policy',
+                content: strictCsp,
+              },
+              injectTo: 'head-prepend',
+            },
+          ],
+        };
+      },
+    });
+  }
+
+  return {
+    base: './',
+    plugins,
+    server: {
+      allowedHosts: true,
+    },
+    test: {
+      environment: 'happy-dom',
+    },
+  };
 });


### PR DESCRIPTION
Enforce strict Content Security Policy (CSP) in production builds to prevent XSS and other code injection attacks.

**Changes:**
- Refactored `vite.config.ts` to use a configuration function for conditional build logic.
- Added a `security-headers` plugin that:
    - Runs only on `build` command.
    - Removes existing permissive CSP tags (used for Dev/HMR).
    - Injects a strict CSP: `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; ...`
- Updated `src/vite-config.test.ts` to verifying the configuration factory pattern.

**Verification:**
- `pnpm test src/vite-config.test.ts` passes.
- `pnpm build` generates `dist/index.html` with the strict CSP tag and no duplicate/permissive tags.

---
*PR created automatically by Jules for task [11672133632123020812](https://jules.google.com/task/11672133632123020812) started by @gfxblit*