### PR TITLE
🎨 Palette: Add keyboard focus states to debug panel elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Interactive Elements Focus States
+**Learning:** Consistently apply `focus:outline-none focus:ring-2 focus:ring-vector-green` across dynamic UI panels to ensure standard keyboard accessibility via tab navigation.
+**Action:** Always include focus states on buttons and inputs.

--- a/src/DebugUIManager.ts
+++ b/src/DebugUIManager.ts
@@ -2,7 +2,7 @@ import { GameState, state, setStage } from './state';
 import { GameConfig } from './config';
 
 export class DebugUIManager {
-  private static readonly BUTTON_CLASSES = 'px-2 py-1 border border-vector-green hover:bg-vector-green hover:text-black transition-colors font-retro text-[9px]';
+  private static readonly BUTTON_CLASSES = 'px-2 py-1 border border-vector-green hover:bg-vector-green hover:text-black transition-colors font-retro text-[9px] focus:outline-none focus:ring-2 focus:ring-vector-green';
 
   private debugPanel?: HTMLElement;
   private tieFighterCountValue?: HTMLElement;
@@ -122,7 +122,7 @@ export class DebugUIManager {
     const title = this.createEl('div', '', header);
     title.textContent = 'DEBUG CONSOLE';
 
-    const toggleBtn = this.createEl('button', 'ml-4 hover:text-white transition-colors font-retro', header);
+    const toggleBtn = this.createEl('button', 'ml-4 hover:text-white transition-colors font-retro focus:outline-none focus:ring-2 focus:ring-vector-green', header);
     toggleBtn.id = 'debug-minimize-toggle';
     toggleBtn.textContent = '[-]';
     toggleBtn.setAttribute('aria-label', 'Minimize Debug Console');
@@ -194,7 +194,7 @@ export class DebugUIManager {
 
   private createLabeledInput(label: string, id: string, type: string, value: string, placeholder: string, onChange: (e: Event) => void, parent: HTMLElement, ariaLabel?: string) {
     const row = this.createDebugRow(label, parent);
-    const input = this.createEl('input', 'w-24 bg-black text-vector-green border border-vector-green px-2 py-1 text-right', row) as HTMLInputElement;
+    const input = this.createEl('input', 'w-24 bg-black text-vector-green border border-vector-green px-2 py-1 text-right focus:outline-none focus:ring-2 focus:ring-vector-green', row) as HTMLInputElement;
     input.id = id;
     
     let effectiveAriaLabel = label;

--- a/src/UIManager_Accessibility.test.ts
+++ b/src/UIManager_Accessibility.test.ts
@@ -54,6 +54,26 @@ describe('UIManager Accessibility', () => {
     expect(fireballSizeInput?.getAttribute('aria-label')).toBe('Fireball Size');
   });
 
+  it('should include focus styles on interactive elements for keyboard navigability', () => {
+    // Buttons
+    const aiToggle = document.getElementById('ai-mode-toggle');
+    expect(aiToggle?.className).toContain('focus:outline-none');
+    expect(aiToggle?.className).toContain('focus:ring-2');
+    expect(aiToggle?.className).toContain('focus:ring-vector-green');
+
+    // Minimize toggle
+    const minimizeToggle = document.getElementById('debug-minimize-toggle');
+    expect(minimizeToggle?.className).toContain('focus:outline-none');
+    expect(minimizeToggle?.className).toContain('focus:ring-2');
+    expect(minimizeToggle?.className).toContain('focus:ring-vector-green');
+
+    // Inputs
+    const killsInput = document.getElementById('debug-kills-input');
+    expect(killsInput?.className).toContain('focus:outline-none');
+    expect(killsInput?.className).toContain('focus:ring-2');
+    expect(killsInput?.className).toContain('focus:ring-vector-green');
+  });
+
   it('should have aria-pressed on toggle buttons reflecting state', () => {
     // AI Toggle
     const aiToggle = document.getElementById('ai-mode-toggle');


### PR DESCRIPTION
💡 **What**: Added `focus:outline-none focus:ring-2 focus:ring-vector-green` utility classes to the Debug Panel's buttons and input fields (`DebugUIManager.ts`). Also updated `UIManager_Accessibility.test.ts` to assert that these interactive elements properly include these focus classes.
🎯 **Why**: Navigating via keyboard (using the Tab key) previously provided no clear visual indication of which element inside the Debug Panel was currently focused, causing a poor accessibility experience. This ensures an obvious and thematic outline is shown.
📸 **Before/After**: Screenshots generated and verified via Playwright.
♿ **Accessibility**: Enhanced keyboard navigability by providing a visible focus indicator compliant with typical accessibility guidelines, while maintaining the retro green aesthetic.

---
*PR created automatically by Jules for task [5729434438479374965](https://jules.google.com/task/5729434438479374965) started by @gfxblit*