### PR TITLE
⚡ Bolt: [performance improvement] Reduce GC pressure by replacing `getTargets` array allocation with `forEachTarget` in `CombatStrategies`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2024-10-24 - Closure Reassignment Narrowing with TypeScript
+**Learning:** When passing synchronous callbacks to hot-path iterators (like `forEachTarget`) in TypeScript, modifying locally scoped primitive/reference variables from the outer scope within the callback can cause control flow analysis to incorrectly narrow types (e.g., throwing TS errors about assigning to `null`).
+**Action:** Use mutable object wrappers (e.g., `const state = { target: null as Targetable | null, dist: Infinity }`) for variables captured and modified inside these synchronous callbacks to sidestep compiler limitations.
+
+## 2024-10-24 - Zero Allocation Iteration Over Multiple Collections
+**Learning:** `EntityManager` was allocating temporary arrays every frame using spread syntax `[...this.tieFighters, ...this.additionalTargets]` to provide iterators for `checkTargets`. This caused excessive GC pressure in hot paths.
+**Action:** Implement `forEachTarget(callback)` directly on the manager class which runs individual `for...of` loops over each internal collection sequentially, passing each element to the callback without ever allocating intermediate array structures.

--- a/src/CombatStrategies.ts
+++ b/src/CombatStrategies.ts
@@ -39,13 +39,16 @@ abstract class BaseCombatStrategy implements CombatStrategy {
   protected checkTargets(input: UserInput, camera: THREE.Camera) {
     if (!state.entityManager) return;
 
-    let closestTarget: Targetable | null = null;
-    let closestDist = Infinity;
+    // Use a mutable object wrapper to avoid type narrowing bugs in the callback
+    const closest = {
+      target: null as Targetable | null,
+      dist: Infinity
+    };
     
     camera.getWorldPosition(this.scratchCameraPos);
 
-    for (const target of state.entityManager.getTargets()) {
-      if (target.isExploded) continue;
+    state.entityManager.forEachTarget((target) => {
+      if (target.isExploded) return;
 
       // Check all possible target points if the entity provides them, otherwise use base world position
       const targetPoints = target.getTargetPositions ? 
@@ -65,16 +68,16 @@ abstract class BaseCombatStrategy implements CombatStrategy {
         }
       }
 
-      if (isHit && hitDist < closestDist && hitDist < this.config.maxRange) {
-        closestDist = hitDist;
-        closestTarget = target;
+      if (isHit && hitDist < closest.dist && hitDist < this.config.maxRange) {
+        closest.dist = hitDist;
+        closest.target = target;
       }
-    }
+    });
 
     // Only explode the single closest target that was aimed at
-    if (closestTarget) {
-      closestTarget.explode();
-      addScore(closestTarget.getScore());
+    if (closest.target) {
+      closest.target.explode();
+      addScore(closest.target.getScore());
       addKill();
     }
   }

--- a/src/entities/EntityManager.ts
+++ b/src/entities/EntityManager.ts
@@ -314,6 +314,19 @@ export class EntityManager {
     return [...this.tieFighters, ...this.additionalTargets];
   }
 
+  /**
+   * Iterates over all current targets without allocating intermediate arrays,
+   * avoiding garbage collection pressure in hot paths.
+   */
+  public forEachTarget(callback: (target: Targetable) => void): void {
+    for (const tf of this.tieFighters) {
+      callback(tf);
+    }
+    for (const target of this.additionalTargets) {
+      callback(target);
+    }
+  }
+
   public removeTarget(target: Targetable): void {
     const index = this.additionalTargets.indexOf(target);
     if (index !== -1) {

--- a/src/entities/EntityManager_Optimization.test.ts
+++ b/src/entities/EntityManager_Optimization.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { EntityManager } from './EntityManager';
+import * as THREE from 'three';
+import { AIStrategyFactory } from './AIStrategyFactory';
+import { Targetable } from './Entity';
+
+describe('EntityManager Optimization', () => {
+  let entityManager: EntityManager;
+  let worldScene: THREE.Scene;
+  let hudScene: THREE.Scene;
+
+  beforeEach(() => {
+    worldScene = new THREE.Scene();
+    hudScene = new THREE.Scene();
+    entityManager = new EntityManager(worldScene, hudScene, new AIStrategyFactory());
+  });
+
+  it('forEachTarget should iterate over all tieFighters and additionalTargets', () => {
+    // Add two tie fighters
+    entityManager.spawnTieFighter(false);
+    entityManager.spawnTieFighter(true);
+
+    // Create a mock additional target
+    const mockTarget: Targetable = {
+      position: new THREE.Vector3(),
+      isExploded: false,
+      explode: () => {},
+      getScore: () => 100,
+      getWorldPosition: (out: THREE.Vector3) => out.set(0, 0, 0),
+      update: () => null,
+    };
+    entityManager.addTarget(mockTarget);
+
+    const iteratedTargets: Targetable[] = [];
+
+    // Run the optimized iteration method
+    entityManager.forEachTarget((target) => {
+      iteratedTargets.push(target);
+    });
+
+    // The total iterated targets should equal the tie fighters (2) + additional target (1)
+    expect(iteratedTargets.length).toBe(3);
+
+    // Ensure the mock target is in the list
+    expect(iteratedTargets).toContain(mockTarget);
+
+    // Ensure tie fighters are in the list
+    const tieFighters = entityManager.getTieFighters();
+    expect(iteratedTargets).toContain(tieFighters[0]);
+    expect(iteratedTargets).toContain(tieFighters[1]);
+  });
+});


### PR DESCRIPTION
💡 **What**: Replaced the `state.entityManager.getTargets()` call in `BaseCombatStrategy.checkTargets` with `state.entityManager.forEachTarget()`.
🎯 **Why**: Previously, `getTargets()` was called every frame when the player was firing. It allocated a new array combining two internal arrays using spread syntax `[...this.tieFighters, ...this.additionalTargets]`. In hot paths, this created immense Garbage Collection (GC) pressure. `forEachTarget` eliminates this allocation by looping over both internal arrays and invoking a provided callback for each item directly.
📊 **Impact**: Reduces array allocations during firing to 0. 
🔬 **Measurement**: Run the performance regression test suite.
🧠 **Learning**: To safely assign multiple variables across a closure scope where control flow analysis fails, we wrap the output variables in an object (e.g. `closest`) inside `checkTargets`.

---
*PR created automatically by Jules for task [16122010058199233757](https://jules.google.com/task/16122010058199233757) started by @gfxblit*