### PR TITLE
🛡️ Sentinel: [HIGH] Fix Permissive Content Security Policy (CSP) in Production

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Strict CSP for Production Builds]
+**Vulnerability:** Permissive Content Security Policy (CSP) allowed `unsafe-eval` and `unsafe-inline` for scripts in the production build.
+**Learning:** The development environment (Vite) requires a permissive CSP for HMR and development scripts, but this introduces an XSS risk in production.
+**Prevention:** Use a custom Vite plugin during the `build` process to replace the permissive development CSP meta tag with a strict, production-ready CSP tag using the `transformIndexHtml` hook.

--- a/src/vite-config.test.ts
+++ b/src/vite-config.test.ts
@@ -6,7 +6,8 @@ describe('Vite Configuration', () => {
     // We expect the server configuration to exist and allowedHosts to be true
     // Casting to any because the type definition might not explicitly include allowedHosts 
     // depending on the Vite version, but it is a valid config option.
-    const serverConfig = (config as any).server;
+    const resolvedConfig = typeof config === 'function' ? config({ command: 'serve', mode: 'development' }) : config;
+    const serverConfig = (resolvedConfig as any).server;
     expect(serverConfig).toBeDefined();
     expect(serverConfig.allowedHosts).toBe(true);
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,29 @@
 import { defineConfig } from 'vite';
 
-export default defineConfig({
-  base: './',
-  server: {
-    allowedHosts: true,
-  },
-  test: {
-    environment: 'happy-dom',
-  },
+export default defineConfig(({ command }) => {
+  return {
+    base: './',
+    server: {
+      allowedHosts: true,
+    },
+    test: {
+      environment: 'happy-dom',
+    },
+    plugins: [
+      {
+        name: 'strict-csp',
+        transformIndexHtml(html) {
+          if (command === 'build') {
+            const strictCSP = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self';";
+            const withoutOldCSP = html.replace(/<meta[^>]+http-equiv=['"]Content-Security-Policy['"][^>]*>/gi, '');
+            return withoutOldCSP.replace(
+              /<head>/i,
+              `<head>\n    <meta http-equiv="Content-Security-Policy" content="${strictCSP}">`
+            );
+          }
+          return html;
+        }
+      }
+    ]
+  };
 });


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The existing Content Security Policy (CSP) tag in `index.html` permitted `unsafe-eval` and `unsafe-inline` for scripts (`script-src`). While necessary for Vite's development HMR, retaining this in production poses a significant Cross-Site Scripting (XSS) vulnerability.
🎯 **Impact:** If an attacker finds a way to inject data, the permissive CSP would allow them to execute arbitrary inline scripts or `eval()` code in the victim's browser, potentially leading to session hijacking, data theft, or complete compromise of the application context.
🔧 **Fix:** Refactored `vite.config.ts` to export a configuration factory function. Implemented a custom Vite plugin (`strict-csp`) that hooks into `transformIndexHtml`. When `command === 'build'` (production), it replaces the permissive development CSP meta tag with a strict, secure CSP tag that removes script-related unsafe directives.
✅ **Verification:** Verified by running `pnpm build` and inspecting `dist/index.html` to confirm the strict CSP is present. Also verified that `pnpm test` and `pnpm lint` pass successfully.

---
*PR created automatically by Jules for task [6247575671753657679](https://jules.google.com/task/6247575671753657679) started by @gfxblit*