### PR TITLE
🛡️ Sentinel: [HIGH] Fix Permissive Production CSP

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-01 - Strict Production Content Security Policy (CSP)
+**Vulnerability:** Permissive CSP directives (`unsafe-inline`, `unsafe-eval`) required for Vite development mode were being shipped to production, weakening protection against Cross-Site Scripting (XSS).
+**Learning:** Development-specific security overrides must be removed during the build process. A Vite configuration factory function can inject a strict production CSP only when `command === 'build'`, ensuring secure builds without breaking the local development server.
+**Prevention:** Implement conditional logic in `vite.config.ts` using custom plugins to transform `index.html` dynamically based on the current environment (dev vs. prod).

--- a/src/vite-config.test.ts
+++ b/src/vite-config.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import config from '../vite.config';
+import configFactory from '../vite.config';
 
 describe('Vite Configuration', () => {
   it('allows external hosts in server configuration', () => {
+    // Determine the configuration using the factory function
+    const config = typeof configFactory === 'function' ? configFactory({ command: 'serve', mode: 'development' }) : configFactory;
+
     // We expect the server configuration to exist and allowedHosts to be true
-    // Casting to any because the type definition might not explicitly include allowedHosts 
-    // depending on the Vite version, but it is a valid config option.
     const serverConfig = (config as any).server;
     expect(serverConfig).toBeDefined();
     expect(serverConfig.allowedHosts).toBe(true);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,39 @@
-import { defineConfig } from 'vite';
+import { defineConfig, HtmlTagDescriptor } from 'vite';
 
-export default defineConfig({
-  base: './',
-  server: {
-    allowedHosts: true,
-  },
-  test: {
-    environment: 'happy-dom',
-  },
+const strictCsp = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self';";
+
+export default defineConfig(({ command }) => {
+  return {
+    base: './',
+    server: {
+      allowedHosts: true,
+    },
+    test: {
+      environment: 'happy-dom',
+    },
+    plugins: [
+      command === 'build' ? {
+        name: 'inject-strict-csp',
+        enforce: 'pre',
+        transformIndexHtml(html) {
+          // Remove any existing CSP tags
+          const cleanHtml = html.replace(/<meta\s+http-equiv=["']Content-Security-Policy["'][^>]*>/gi, '');
+
+          const cspTag: HtmlTagDescriptor = {
+            tag: 'meta',
+            attrs: {
+              'http-equiv': 'Content-Security-Policy',
+              content: strictCsp
+            },
+            injectTo: 'head-prepend'
+          };
+
+          return {
+            html: cleanHtml,
+            tags: [cspTag]
+          };
+        }
+      } : undefined
+    ]
+  };
 });


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was shipping development-specific, permissive CSP directives (`unsafe-inline`, `unsafe-eval`) to the production build via `index.html`, weakening protection against Cross-Site Scripting (XSS) attacks.
🎯 **Impact:** An attacker could potentially execute malicious JavaScript in the context of the user's browser if an XSS vulnerability was found elsewhere in the application.
🔧 **Fix:** Refactored `vite.config.ts` to use a configuration factory function and added a custom Vite plugin. This plugin strips the permissive CSP meta tag from `index.html` and injects a strict production CSP (`default-src 'self' ...`) exclusively during the `build` process. This maintains local dev functionality (HMR) while securing production.
✅ **Verification:**
1.  Run `pnpm build`.
2.  Inspect `dist/index.html` to confirm the CSP meta tag does not contain `unsafe-eval` or script-related `unsafe-inline` directives.
3.  Run `pnpm test` to verify `src/vite-config.test.ts` passes with the new config factory structure.

---
*PR created automatically by Jules for task [5411052491954177394](https://jules.google.com/task/5411052491954177394) started by @gfxblit*