### PR TITLE
🎨 Palette: Add focus visible styles for keyboard navigation in debug panel

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Focus Indicators on Custom Interactive Elements
+**Learning:** When building custom interactive UI components (like the standalone toggle buttons or dynamically generated inputs in the Debug panel), native focus indicators might be absent or insufficient against a complex background (like space).
+**Action:** Always ensure that any element designed to be interacted with via keyboard includes explicit focus utility classes (`focus:outline-none`, `focus:ring-2`, `focus:ring-vector-green`) to guarantee accessibility and navigability.

--- a/src/DebugUIManager.ts
+++ b/src/DebugUIManager.ts
@@ -2,7 +2,7 @@ import { GameState, state, setStage } from './state';
 import { GameConfig } from './config';
 
 export class DebugUIManager {
-  private static readonly BUTTON_CLASSES = 'px-2 py-1 border border-vector-green hover:bg-vector-green hover:text-black transition-colors font-retro text-[9px]';
+  private static readonly BUTTON_CLASSES = 'px-2 py-1 border border-vector-green hover:bg-vector-green hover:text-black transition-colors font-retro text-[9px] focus:outline-none focus:ring-2 focus:ring-vector-green focus:ring-offset-1 focus:ring-offset-black';
 
   private debugPanel?: HTMLElement;
   private tieFighterCountValue?: HTMLElement;
@@ -122,7 +122,7 @@ export class DebugUIManager {
     const title = this.createEl('div', '', header);
     title.textContent = 'DEBUG CONSOLE';
 
-    const toggleBtn = this.createEl('button', 'ml-4 hover:text-white transition-colors font-retro', header);
+    const toggleBtn = this.createEl('button', 'ml-4 hover:text-white transition-colors font-retro focus:outline-none focus:ring-2 focus:ring-vector-green focus:ring-offset-1 focus:ring-offset-black', header);
     toggleBtn.id = 'debug-minimize-toggle';
     toggleBtn.textContent = '[-]';
     toggleBtn.setAttribute('aria-label', 'Minimize Debug Console');
@@ -194,7 +194,7 @@ export class DebugUIManager {
 
   private createLabeledInput(label: string, id: string, type: string, value: string, placeholder: string, onChange: (e: Event) => void, parent: HTMLElement, ariaLabel?: string) {
     const row = this.createDebugRow(label, parent);
-    const input = this.createEl('input', 'w-24 bg-black text-vector-green border border-vector-green px-2 py-1 text-right', row) as HTMLInputElement;
+    const input = this.createEl('input', 'w-24 bg-black text-vector-green border border-vector-green px-2 py-1 text-right focus:outline-none focus:ring-2 focus:ring-vector-green', row) as HTMLInputElement;
     input.id = id;
     
     let effectiveAriaLabel = label;

--- a/src/UIManager_Accessibility.test.ts
+++ b/src/UIManager_Accessibility.test.ts
@@ -76,4 +76,21 @@ describe('UIManager Accessibility', () => {
     chassisToggle?.click();
     expect(chassisToggle?.getAttribute('aria-pressed')).toBe('true');
   });
+
+  it('should have focus classes for keyboard navigability', () => {
+    // Check minimize button
+    const minimizeBtn = document.getElementById('debug-minimize-toggle');
+    expect(minimizeBtn?.className).toContain('focus:ring-2');
+    expect(minimizeBtn?.className).toContain('focus:ring-vector-green');
+
+    // Check an input
+    const killsInput = document.getElementById('debug-kills-input');
+    expect(killsInput?.className).toContain('focus:ring-2');
+    expect(killsInput?.className).toContain('focus:ring-vector-green');
+
+    // Check a toggle button
+    const aiToggle = document.getElementById('ai-mode-toggle');
+    expect(aiToggle?.className).toContain('focus:ring-2');
+    expect(aiToggle?.className).toContain('focus:ring-vector-green');
+  });
 });


### PR DESCRIPTION
💡 What: Added visible focus indicators (Tailwind `focus:ring-2` etc.) to the interactive controls in the Debug Panel.
🎯 Why: To improve accessibility and allow developers to clearly see which element has focus when navigating the debug menu using the keyboard.
📸 Before/After: Visual changes verified via Playwright screenshot.
♿ Accessibility: The debug panel is now fully keyboard navigable with clear visual indicators for interactive elements.

---
*PR created automatically by Jules for task [4070771871558332727](https://jules.google.com/task/4070771871558332727) started by @gfxblit*